### PR TITLE
Expose standalone markdown plugin

### DIFF
--- a/changelog/@unreleased/pr-15.v2.yml
+++ b/changelog/@unreleased/pr-15.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Expose `com.palantir.metric-schema-markdown` plugin which allows any
+    project to opt into metric-schema markdown generation.
+  links:
+  - https://github.com/palantir/metric-schema/pull/15

--- a/gradle-metric-schema/build.gradle
+++ b/gradle-metric-schema/build.gradle
@@ -30,6 +30,10 @@ pluginBundle {
             id = 'com.palantir.metric-schema'
             displayName = 'Metric Schema Plugin'
         }
+        metricSchemaMarkdownPlugin {
+            id = 'com.palantir.metric-schema-markdown'
+            displayName = "Metric Schema Markdown Plugin"
+        }
     }
 }
 

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema.gradle;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.gradle.StartParameter;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+
+public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(LifecycleBasePlugin.class);
+        project.getPluginManager().apply(MetricSchemaPlugin.class);
+
+        TaskProvider<CreateMetricsManifestTask> createMetricsManifest =
+                project.getTasks().named(MetricSchemaPlugin.CREATE_METRICS_MANIFEST, CreateMetricsManifestTask.class);
+
+        TaskProvider<GenerateMetricMarkdownTask> generateMetricsMarkdown = project.getTasks()
+                .register(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN, GenerateMetricMarkdownTask.class, task -> {
+                    task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
+                    task.outputFile().set(project.file("metrics.md"));
+                    task.dependsOn(createMetricsManifest);
+                });
+        project.getTasks().named("check", check -> check.dependsOn(generateMetricsMarkdown));
+
+        // Wire up dependencies so running `./gradlew --write-locks` will update the markdown
+        StartParameter startParam = project.getGradle().getStartParameter();
+        if (startParam.isWriteDependencyLocks()
+                && !startParam.getTaskNames().contains(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN)) {
+            List<String> taskNames = ImmutableList.<String>builder()
+                    .addAll(startParam.getTaskNames())
+                    .add(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN)
+                    .build();
+            startParam.setTaskNames(taskNames);
+        }
+    }
+}

--- a/gradle-metric-schema/src/main/resources/META-INF/gradle-plugins/com.palantir.metric-schema-markdown.properties
+++ b/gradle-metric-schema/src/main/resources/META-INF/gradle-plugins/com.palantir.metric-schema-markdown.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.metric.schema.gradle.MetricSchemaMarkdownPlugin

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
@@ -37,35 +37,21 @@ class GenerateMetricMarkdownIntegrationSpec extends IntegrationSpec {
 
     void setup() {
         buildFile << """
-        buildscript {
-            repositories {
-                jcenter()
-                maven { url 'https://dl.bintray.com/palantir/releases/' }
-            }
-            dependencies {
-                classpath 'com.palantir.sls-packaging:gradle-sls-packaging:${Versions.SLS_PACKAGING}'
+        ${applyPlugin(MetricSchemaMarkdownPlugin.class)}
+
+        repositories {
+            jcenter()
+            maven {
+                url 'https://dl.bintray.com/palantir/releases/'
             }
         }
-        
-        version '1.0.0'
-        group 'com.palantir.test'
-        
-        apply plugin: 'com.palantir.sls-java-service-distribution'
-        ${applyPlugin(MetricSchemaPlugin.class)}
 
-            repositories {
-                jcenter()
-                maven {
-                    url 'https://dl.bintray.com/palantir/releases/'
-                }
+        configurations.all {
+            resolutionStrategy {
+                force 'com.palantir.tritium:tritium-registry:${Versions.TRITIUM}'
+                force 'com.palantir.safe-logging:preconditions:${Versions.SAFE_LOGGING}'
             }
-
-            configurations.all {
-                resolutionStrategy {
-                    force 'com.palantir.tritium:tritium-registry:${Versions.TRITIUM}'
-                    force 'com.palantir.safe-logging:preconditions:${Versions.SAFE_LOGGING}'
-                }
-            }
+        }
         """.stripIndent()
     }
 


### PR DESCRIPTION
## Before this PR
We would only generate a markdown summary of the metrics in the current project if it produced an sls service distribution.

## After this PR
==COMMIT_MSG==
Expose `com.palantir.metric-schema-markdown` plugin which allows any project to opt into metric-schema markdown generation.
==COMMIT_MSG==

## Possible downsides?
Increased API surface area