### PR TITLE
CreateMetricsManifestTask avoids logging noisy stack traces

### DIFF
--- a/changelog/@unreleased/pr-16.v2.yml
+++ b/changelog/@unreleased/pr-16.v2.yml
@@ -1,0 +1,11 @@
+type: fix
+fix:
+  description: |-
+    CreateMetricsManifestTask avoids logging noisy stack traces
+
+    Previously distribution projects which did not produce metrics
+    resulted in exceptions being harmelssly logged due to attempting
+    to open files that did not exist.
+    Now we check for existance first.
+  links:
+  - https://github.com/palantir/metric-schema/pull/16

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
@@ -139,8 +139,13 @@ public class CreateMetricsManifestTask extends DefaultTask {
                     CompileMetricSchemaTask compileMetricSchemaTask = (CompileMetricSchemaTask)
                             dependencyProject.getTasks().getByName(MetricSchemaPlugin.COMPILE_METRIC_SCHEMA);
 
-                    metricSchemaStream = Files.asByteSource(compileMetricSchemaTask.getOutputFile().get().getAsFile())
-                            .openStream();
+                    File file = compileMetricSchemaTask.getOutputFile().get().getAsFile();
+                    if (file.isFile()) {
+                        metricSchemaStream = Files.asByteSource(file).openStream();
+                    } else {
+                        log.debug("File {} does not exist", file);
+                        return Stream.empty();
+                    }
                 } else {
                     if (!artifact.getFile().exists()) {
                         log.debug("Artifact did not exist: {}", artifact.getFile());


### PR DESCRIPTION
Previously distribution projects which did not produce metrics
resulted in exceptions being harmelssly logged due to attempting
to open files that did not exist.
Now we check for existance first.