### PR TITLE
Metric markdown provenance

### DIFF
--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Metric markdown provides provenance. Metrics from the local project
+    (as determined by the artifact group) are listed above those inherited from other
+    projects.
+  links:
+  - https://github.com/palantir/metric-schema/pull/22

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
@@ -66,7 +66,8 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
             return;
         }
 
-        String upToDateContents = MarkdownRenderer.render(schemas);
+        String localCoordinate = "" + getProject().getGroup() + ':' + getProject().getName();
+        String upToDateContents = MarkdownRenderer.render(localCoordinate, schemas);
 
         if (getProject().getGradle().getStartParameter().isWriteDependencyLocks()) {
             GFileUtils.writeFile(upToDateContents, markdown);

--- a/metric-schema-markdown/build.gradle
+++ b/metric-schema-markdown/build.gradle
@@ -12,4 +12,5 @@ dependencies {
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -17,6 +17,7 @@
 package com.palantir.metric.schema.markdown;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.palantir.metric.schema.MetricDefinition;
@@ -25,18 +26,36 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Stream;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 /** {@link MarkdownRenderer} consumes consolidated metric schemas from a distribution to produce metrics in markdown. */
 public final class MarkdownRenderer {
 
     /** Returns rendered markdown based on the provided schemas. */
-    public static String render(Map<String, List<MetricSchema>> schemas) {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append("# Metrics\n");
-        // TODO(forozco): use metric-schema provenance in markdown generation
-        namespaces(schemas.values().stream().flatMap(List::stream)).forEach(namespace -> render(namespace, buffer));
+    public static String render(String localCoordinate, Map<String, List<MetricSchema>> schemas) {
+        StringBuilder buffer = new StringBuilder()
+                .append("# ")
+                .append(displayName(getName(localCoordinate)))
+                .append(" Metrics\n");
+        namespaces(localCoordinate, schemas).forEach(section -> render(section, buffer));
         return CharMatcher.whitespace().trimFrom(buffer.toString());
+    }
+
+    private static void render(Section section, StringBuilder output) {
+        if (section.namespaces().isEmpty()
+                || section.namespaces().stream().allMatch(namespace -> namespace.definition().getMetrics().isEmpty())) {
+            // Don't render sections without metrics.
+            return;
+        }
+        output.append("\n## ")
+                .append(displayName(getName(section.sourceCoordinates())))
+                .append("\n\n")
+                .append('`')
+                .append(section.sourceCoordinates())
+                .append("`\n");
+        section.namespaces().forEach(namespace -> render(namespace, output));
     }
 
     private static void render(Namespace namespace, StringBuilder output) {
@@ -45,7 +64,7 @@ public final class MarkdownRenderer {
             // Don't render namespaces without metrics.
             return;
         }
-        output.append("\n## ")
+        output.append("\n### ")
                 .append(namespace.name())
                 .append('\n')
                 .append(namespace.definition().getDocs().get())
@@ -66,11 +85,65 @@ public final class MarkdownRenderer {
                 .append('\n');
     }
 
-    private static ImmutableList<Namespace> namespaces(Stream<MetricSchema> schemas) {
-        return schemas.flatMap(schema -> schema.getNamespaces().entrySet().stream()
-                        .map(entry -> Namespace.builder().name(entry.getKey()).definition(entry.getValue()).build()))
-                .sorted(Comparator.comparing(Namespace::name))
+    private static ImmutableList<Section> namespaces(String localCoordinate, Map<String, List<MetricSchema>> schemas) {
+        return schemas.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(new CoordinateComparator(localCoordinate)))
+                .map(entry -> Section.builder()
+                        .sourceCoordinates(entry.getKey())
+                        .namespaces(entry.getValue().stream()
+                                .flatMap(schema -> schema.getNamespaces().entrySet().stream())
+                                .map(schemaEntry -> Namespace.builder()
+                                        .name(schemaEntry.getKey())
+                                        .definition(schemaEntry.getValue())
+                                        .build())
+                                .collect(ImmutableList.toImmutableList()))
+                        .build())
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    private static String getName(String coordinate) {
+        List<String> results = Splitter.on(':').splitToList(coordinate);
+        return results.size() >= 2 ? results.get(1) : coordinate;
+    }
+
+    private static String displayName(String name) {
+        return Splitter.on(CharMatcher.whitespace().or(CharMatcher.anyOf("-_.")))
+                .omitEmptyStrings()
+                .trimResults()
+                .splitToList(name)
+                .stream()
+                .map(StringUtils::capitalize)
+                .collect(Collectors.joining(" "));
+    }
+
+    private static String getGroup(String coordinate) {
+        return Splitter.on(':').splitToList(coordinate).get(0);
+    }
+
+    /**
+     * Comparator which prefers sections from the local projects group. Metrics defined in the local project should be
+     * rendered first.
+     */
+    private static final class CoordinateComparator implements Comparator<String> {
+
+        private final String localCoordinate;
+
+        CoordinateComparator(String localCoordinate) {
+            this.localCoordinate = localCoordinate;
+        }
+
+        @Override
+        public int compare(String first, String second) {
+            String firstGroup = getGroup(first);
+            String secondGroup = getGroup(second);
+            if (Objects.equals(firstGroup, localCoordinate) || Objects.equals(secondGroup, localCoordinate)) {
+                if (Objects.equals(firstGroup, secondGroup)) {
+                    return 0;
+                }
+                return Objects.equals(firstGroup, localCoordinate) ? -1 : 1;
+            }
+            return first.compareTo(second);
+        }
     }
 
     private MarkdownRenderer() {}

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -27,16 +27,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 
 /** {@link MarkdownRenderer} consumes consolidated metric schemas from a distribution to produce metrics in markdown. */
 public final class MarkdownRenderer {
 
     /** Returns rendered markdown based on the provided schemas. */
     public static String render(String localCoordinate, Map<String, List<MetricSchema>> schemas) {
-        StringBuilder buffer = new StringBuilder()
-                .append("# Metrics\n");
+        StringBuilder buffer = new StringBuilder().append("# Metrics\n");
         namespaces(localCoordinate, schemas).forEach(section -> render(section, buffer));
         return CharMatcher.whitespace().trimFrom(buffer.toString());
     }
@@ -47,12 +44,7 @@ public final class MarkdownRenderer {
             // Don't render sections without metrics.
             return;
         }
-        output.append("\n## ")
-                .append(displayName(getName(section.sourceCoordinates())))
-                .append("\n\n")
-                .append('`')
-                .append(section.sourceCoordinates())
-                .append("`\n");
+        output.append("\n## `").append(section.sourceCoordinates()).append("`\n");
         section.namespaces().forEach(namespace -> render(namespace, output));
     }
 
@@ -89,7 +81,8 @@ public final class MarkdownRenderer {
                 .map(entry -> Section.builder()
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
-                                .flatMap(schema -> schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
+                                .flatMap(schema ->
+                                        schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
                                 .map(schemaEntry -> Namespace.builder()
                                         .name(schemaEntry.getKey())
                                         .definition(schemaEntry.getValue())
@@ -97,21 +90,6 @@ public final class MarkdownRenderer {
                                 .collect(ImmutableList.toImmutableList()))
                         .build())
                 .collect(ImmutableList.toImmutableList());
-    }
-
-    private static String getName(String coordinate) {
-        List<String> results = Splitter.on(':').splitToList(coordinate);
-        return results.size() >= 2 ? results.get(1) : coordinate;
-    }
-
-    private static String displayName(String name) {
-        return Splitter.on(CharMatcher.whitespace().or(CharMatcher.anyOf("-_.")))
-                .omitEmptyStrings()
-                .trimResults()
-                .splitToList(name)
-                .stream()
-                .map(StringUtils::capitalize)
-                .collect(Collectors.joining(" "));
     }
 
     private static String getGroup(String coordinate) {

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -27,13 +27,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 /** {@link MarkdownRenderer} consumes consolidated metric schemas from a distribution to produce metrics in markdown. */
 public final class MarkdownRenderer {
 
     /** Returns rendered markdown based on the provided schemas. */
     public static String render(String localCoordinate, Map<String, List<MetricSchema>> schemas) {
-        StringBuilder buffer = new StringBuilder().append("# Metrics\n");
+        StringBuilder buffer = new StringBuilder()
+                .append("# Metrics\n");
         namespaces(localCoordinate, schemas).forEach(section -> render(section, buffer));
         return CharMatcher.whitespace().trimFrom(buffer.toString());
     }
@@ -44,7 +47,12 @@ public final class MarkdownRenderer {
             // Don't render sections without metrics.
             return;
         }
-        output.append("\n## `").append(section.sourceCoordinates()).append("`\n");
+        output.append("\n## ")
+                .append(displayName(getName(section.sourceCoordinates())))
+                .append("\n\n")
+                .append('`')
+                .append(section.sourceCoordinates())
+                .append("`\n");
         section.namespaces().forEach(namespace -> render(namespace, output));
     }
 
@@ -81,8 +89,7 @@ public final class MarkdownRenderer {
                 .map(entry -> Section.builder()
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
-                                .flatMap(schema ->
-                                        schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
+                                .flatMap(schema -> schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
                                 .map(schemaEntry -> Namespace.builder()
                                         .name(schemaEntry.getKey())
                                         .definition(schemaEntry.getValue())
@@ -90,6 +97,21 @@ public final class MarkdownRenderer {
                                 .collect(ImmutableList.toImmutableList()))
                         .build())
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    private static String getName(String coordinate) {
+        List<String> results = Splitter.on(':').splitToList(coordinate);
+        return results.size() >= 2 ? results.get(1) : coordinate;
+    }
+
+    private static String displayName(String name) {
+        return Splitter.on(CharMatcher.whitespace().or(CharMatcher.anyOf("-_.")))
+                .omitEmptyStrings()
+                .trimResults()
+                .splitToList(name)
+                .stream()
+                .map(StringUtils::capitalize)
+                .collect(Collectors.joining(" "));
     }
 
     private static String getGroup(String coordinate) {

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -35,8 +35,7 @@ public final class MarkdownRenderer {
 
     /** Returns rendered markdown based on the provided schemas. */
     public static String render(String localCoordinate, Map<String, List<MetricSchema>> schemas) {
-        StringBuilder buffer = new StringBuilder()
-                .append("# Metrics\n");
+        StringBuilder buffer = new StringBuilder().append("# Metrics\n");
         namespaces(localCoordinate, schemas).forEach(section -> render(section, buffer));
         return CharMatcher.whitespace().trimFrom(buffer.toString());
     }
@@ -89,7 +88,8 @@ public final class MarkdownRenderer {
                 .map(entry -> Section.builder()
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
-                                .flatMap(schema -> schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
+                                .flatMap(schema ->
+                                        schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
                                 .map(schemaEntry -> Namespace.builder()
                                         .name(schemaEntry.getKey())
                                         .definition(schemaEntry.getValue())

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -36,9 +36,7 @@ public final class MarkdownRenderer {
     /** Returns rendered markdown based on the provided schemas. */
     public static String render(String localCoordinate, Map<String, List<MetricSchema>> schemas) {
         StringBuilder buffer = new StringBuilder()
-                .append("# ")
-                .append(displayName(getName(localCoordinate)))
-                .append(" Metrics\n");
+                .append("# Metrics\n");
         namespaces(localCoordinate, schemas).forEach(section -> render(section, buffer));
         return CharMatcher.whitespace().trimFrom(buffer.toString());
     }
@@ -91,7 +89,7 @@ public final class MarkdownRenderer {
                 .map(entry -> Section.builder()
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
-                                .flatMap(schema -> schema.getNamespaces().entrySet().stream())
+                                .flatMap(schema -> schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
                                 .map(schemaEntry -> Namespace.builder()
                                         .name(schemaEntry.getKey())
                                         .definition(schemaEntry.getValue())

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/Namespace.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/Namespace.java
@@ -23,7 +23,6 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
         overshadowImplementation = true,
         jdkOnly = true,
         get = {"get*", "is*"})

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/Section.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/Section.java
@@ -18,7 +18,7 @@ package com.palantir.metric.schema.markdown;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.palantir.metric.schema.MetricNamespace;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -27,15 +27,15 @@ import org.immutables.value.Value;
         overshadowImplementation = true,
         jdkOnly = true,
         get = {"get*", "is*"})
-@JsonDeserialize(as = ImmutableNamespace.class)
-@JsonSerialize(as = ImmutableNamespace.class)
-interface Namespace {
+@JsonDeserialize(as = ImmutableSection.class)
+@JsonSerialize(as = ImmutableSection.class)
+interface Section {
 
-    String name();
+    String sourceCoordinates();
 
-    MetricNamespace definition();
+    List<Namespace> namespaces();
 
-    class Builder extends ImmutableNamespace.Builder {}
+    class Builder extends ImmutableSection.Builder {}
 
     static Builder builder() {
         return new Builder();

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/Section.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/Section.java
@@ -23,7 +23,6 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
         overshadowImplementation = true,
         jdkOnly = true,
         get = {"get*", "is*"})

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -32,7 +32,7 @@ class MarkdownRendererTest {
     @Test
     void testSimple() {
         String markdown = MarkdownRenderer.render(
-                ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(MetricSchema.builder()
+                "com.palantir:test", ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(MetricSchema.builder()
                         .namespaces("namespace", MetricNamespace.builder()
                                 .docs(Documentation.of("namespace docs"))
                                 .metrics("metric", MetricDefinition.builder()
@@ -41,8 +41,13 @@ class MarkdownRendererTest {
                                         .build())
                                 .build())
                         .build())));
-        assertThat(markdown).isEqualTo("# Metrics\n\n"
-                + "## namespace\n"
+        assertThat(markdown).isEqualTo("# Test Metrics\n"
+                + "\n"
+                + "## Test\n"
+                + "\n"
+                + "`com.palantir:test:1.0.0`\n"
+                + "\n"
+                + "### namespace\n"
                 + "namespace docs\n"
                 + "- `namespace.metric` (meter): metric docs");
     }
@@ -50,7 +55,7 @@ class MarkdownRendererTest {
     @Test
     void testTagged() {
         String markdown = MarkdownRenderer.render(
-                ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(MetricSchema.builder()
+                "com.palantir:test", ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(MetricSchema.builder()
                         .namespaces("namespace", MetricNamespace.builder()
                                 .docs(Documentation.of("namespace docs"))
                                 .metrics("metric", MetricDefinition.builder()
@@ -61,8 +66,13 @@ class MarkdownRendererTest {
                                         .build())
                                 .build())
                         .build())));
-        assertThat(markdown).isEqualTo("# Metrics\n\n"
-                + "## namespace\n"
+        assertThat(markdown).isEqualTo("# Test Metrics\n"
+                + "\n"
+                + "## Test\n"
+                + "\n"
+                + "`com.palantir:test:1.0.0`\n"
+                + "\n"
+                + "### namespace\n"
                 + "namespace docs\n"
                 + "- `namespace.metric` tagged `service`, `endpoint` (meter): metric docs");
     }
@@ -70,7 +80,7 @@ class MarkdownRendererTest {
     @Test
     void testEmptyNamespacesExcluded() {
         String markdown = MarkdownRenderer.render(
-                ImmutableMap.of("com.palantir.test", ImmutableList.of(MetricSchema.builder()
+                "com.palantir:test", ImmutableMap.of("com.palantir:test", ImmutableList.of(MetricSchema.builder()
                         .namespaces("com.foo.namespace", MetricNamespace.builder()
                                 .docs(Documentation.of("Foo namespace docs"))
                                 .metrics("metric", MetricDefinition.builder()
@@ -82,8 +92,13 @@ class MarkdownRendererTest {
                                 .docs(Documentation.of("empty namespace docs"))
                                 .build())
                         .build())));
-        assertThat(markdown).isEqualTo("# Metrics\n\n"
-                + "## com.foo.namespace\n"
+        assertThat(markdown).isEqualTo("# Test Metrics\n"
+                + "\n"
+                + "## Test\n"
+                + "\n"
+                + "`com.palantir:test`\n"
+                + "\n"
+                + "### com.foo.namespace\n"
                 + "Foo namespace docs\n"
                 + "- `com.foo.namespace.metric` (meter): metric docs");
     }

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -50,9 +50,7 @@ class MarkdownRendererTest {
                         .build())));
         assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
-                + "## Test\n"
-                + "\n"
-                + "`com.palantir:test:1.0.0`\n"
+                + "## `com.palantir:test:1.0.0`\n"
                 + "\n"
                 + "### anamespace\n"
                 + "namespace docs\n"
@@ -79,9 +77,7 @@ class MarkdownRendererTest {
                         .build())));
         assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
-                + "## Test\n"
-                + "\n"
-                + "`com.palantir:test:1.0.0`\n"
+                + "## `com.palantir:test:1.0.0`\n"
                 + "\n"
                 + "### namespace\n"
                 + "namespace docs\n"
@@ -105,9 +101,7 @@ class MarkdownRendererTest {
                         .build())));
         assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
-                + "## Test\n"
-                + "\n"
-                + "`com.palantir:test`\n"
+                + "## `com.palantir:test`\n"
                 + "\n"
                 + "### com.foo.namespace\n"
                 + "Foo namespace docs\n"

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -50,7 +50,9 @@ class MarkdownRendererTest {
                         .build())));
         assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
-                + "## `com.palantir:test:1.0.0`\n"
+                + "## Test\n"
+                + "\n"
+                + "`com.palantir:test:1.0.0`\n"
                 + "\n"
                 + "### anamespace\n"
                 + "namespace docs\n"
@@ -77,7 +79,9 @@ class MarkdownRendererTest {
                         .build())));
         assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
-                + "## `com.palantir:test:1.0.0`\n"
+                + "## Test\n"
+                + "\n"
+                + "`com.palantir:test:1.0.0`\n"
                 + "\n"
                 + "### namespace\n"
                 + "namespace docs\n"
@@ -101,7 +105,9 @@ class MarkdownRendererTest {
                         .build())));
         assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
-                + "## `com.palantir:test`\n"
+                + "## Test\n"
+                + "\n"
+                + "`com.palantir:test`\n"
                 + "\n"
                 + "### com.foo.namespace\n"
                 + "Foo namespace docs\n"

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -40,13 +40,24 @@ class MarkdownRendererTest {
                                         .docs(Documentation.of("metric docs"))
                                         .build())
                                 .build())
+                        .namespaces("anamespace", MetricNamespace.builder()
+                                .docs(Documentation.of("namespace docs"))
+                                .metrics("metric", MetricDefinition.builder()
+                                        .type(MetricType.METER)
+                                        .docs(Documentation.of("metric docs"))
+                                        .build())
+                                .build())
                         .build())));
-        assertThat(markdown).isEqualTo("# Test Metrics\n"
+        assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
                 + "## Test\n"
                 + "\n"
                 + "`com.palantir:test:1.0.0`\n"
                 + "\n"
+                + "### anamespace\n"
+                + "namespace docs\n"
+                + "- `anamespace.metric` (meter): metric docs"
+                + "\n\n"
                 + "### namespace\n"
                 + "namespace docs\n"
                 + "- `namespace.metric` (meter): metric docs");
@@ -66,7 +77,7 @@ class MarkdownRendererTest {
                                         .build())
                                 .build())
                         .build())));
-        assertThat(markdown).isEqualTo("# Test Metrics\n"
+        assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
                 + "## Test\n"
                 + "\n"
@@ -92,7 +103,7 @@ class MarkdownRendererTest {
                                 .docs(Documentation.of("empty namespace docs"))
                                 .build())
                         .build())));
-        assertThat(markdown).isEqualTo("# Test Metrics\n"
+        assertThat(markdown).isEqualTo("# Metrics\n"
                 + "\n"
                 + "## Test\n"
                 + "\n"


### PR DESCRIPTION
Metrics from the local project (as determined by the artifact group)
are listed above those inherited from other projects.

## Before this PR
No way to tell where a metric was defined.

## After this PR
==COMMIT_MSG==
Metric markdown provides provenance. Metrics from the local project (as determined by the artifact group) are listed above those inherited from other projects.
==COMMIT_MSG==