### PR TITLE
Stable markdown order regardless of the input schema order

### DIFF
--- a/changelog/@unreleased/pr-26.v2.yml
+++ b/changelog/@unreleased/pr-26.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Stable markdown order regardless of the input schema order. Prevents
+    failing checks due to build order differences.
+  links:
+  - https://github.com/palantir/metric-schema/pull/26

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -88,8 +88,8 @@ public final class MarkdownRenderer {
                 .map(entry -> Section.builder()
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
-                                .flatMap(schema ->
-                                        schema.getNamespaces().entrySet().stream().sorted(Map.Entry.comparingByKey()))
+                                .flatMap(schema -> schema.getNamespaces().entrySet().stream())
+                                .sorted(Map.Entry.comparingByKey())
                                 .map(schemaEntry -> Namespace.builder()
                                         .name(schemaEntry.getKey())
                                         .definition(schemaEntry.getValue())

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -31,24 +31,40 @@ class MarkdownRendererTest {
 
     @Test
     void testSimple() {
-        String markdown = MarkdownRenderer.render(
-                "com.palantir:test", ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(MetricSchema.builder()
-                        .namespaces("namespace", MetricNamespace.builder()
-                                .docs(Documentation.of("namespace docs"))
-                                .metrics("metric", MetricDefinition.builder()
-                                        .type(MetricType.METER)
-                                        .docs(Documentation.of("metric docs"))
-                                        .build())
+        MetricSchema firstSchema = MetricSchema.builder()
+                .namespaces("namespace", MetricNamespace.builder()
+                        .docs(Documentation.of("namespace docs"))
+                        .metrics("metric", MetricDefinition.builder()
+                                .type(MetricType.METER)
+                                .docs(Documentation.of("metric docs"))
                                 .build())
-                        .namespaces("anamespace", MetricNamespace.builder()
-                                .docs(Documentation.of("namespace docs"))
-                                .metrics("metric", MetricDefinition.builder()
-                                        .type(MetricType.METER)
-                                        .docs(Documentation.of("metric docs"))
-                                        .build())
+                        .build())
+                .namespaces("anamespace", MetricNamespace.builder()
+                        .docs(Documentation.of("namespace docs"))
+                        .metrics("metric", MetricDefinition.builder()
+                                .type(MetricType.METER)
+                                .docs(Documentation.of("metric docs"))
                                 .build())
-                        .build())));
-        assertThat(markdown).isEqualTo("# Metrics\n"
+                        .build())
+                .build();
+        MetricSchema secondSchema = MetricSchema.builder()
+                .namespaces("secondSchema", MetricNamespace.builder()
+                        .docs(Documentation.of("namespace docs"))
+                        .metrics("metric", MetricDefinition.builder()
+                                .type(MetricType.METER)
+                                .docs(Documentation.of("metric docs"))
+                                .build())
+                        .build())
+                .build();
+        String firstMarkdown = MarkdownRenderer.render(
+                "com.palantir:test",
+                ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(firstSchema, secondSchema)));
+        String secondMarkdown = MarkdownRenderer.render(
+                "com.palantir:test",
+                ImmutableMap.of("com.palantir:test:1.0.0",
+                        // reverse order should produce the same results
+                        ImmutableList.of(secondSchema, firstSchema)));
+        assertThat(firstMarkdown).isEqualTo("# Metrics\n"
                 + "\n"
                 + "## Test\n"
                 + "\n"
@@ -56,11 +72,16 @@ class MarkdownRendererTest {
                 + "\n"
                 + "### anamespace\n"
                 + "namespace docs\n"
-                + "- `anamespace.metric` (meter): metric docs"
-                + "\n\n"
+                + "- `anamespace.metric` (meter): metric docs\n"
+                + "\n"
                 + "### namespace\n"
                 + "namespace docs\n"
-                + "- `namespace.metric` (meter): metric docs");
+                + "- `namespace.metric` (meter): metric docs\n"
+                + "\n"
+                + "### secondSchema\n"
+                + "namespace docs\n"
+                + "- `secondSchema.metric` (meter): metric docs")
+        .isEqualTo(secondMarkdown);
     }
 
     @Test

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -56,32 +56,31 @@ class MarkdownRendererTest {
                                 .build())
                         .build())
                 .build();
-        String firstMarkdown = MarkdownRenderer.render(
-                "com.palantir:test",
-                ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(firstSchema, secondSchema)));
-        String secondMarkdown = MarkdownRenderer.render(
-                "com.palantir:test",
-                ImmutableMap.of("com.palantir:test:1.0.0",
-                        // reverse order should produce the same results
-                        ImmutableList.of(secondSchema, firstSchema)));
-        assertThat(firstMarkdown).isEqualTo("# Metrics\n"
-                + "\n"
-                + "## Test\n"
-                + "\n"
-                + "`com.palantir:test:1.0.0`\n"
-                + "\n"
-                + "### anamespace\n"
-                + "namespace docs\n"
-                + "- `anamespace.metric` (meter): metric docs\n"
-                + "\n"
-                + "### namespace\n"
-                + "namespace docs\n"
-                + "- `namespace.metric` (meter): metric docs\n"
-                + "\n"
-                + "### secondSchema\n"
-                + "namespace docs\n"
-                + "- `secondSchema.metric` (meter): metric docs")
-        .isEqualTo(secondMarkdown);
+        String firstMarkdown = MarkdownRenderer.render("com.palantir:test", ImmutableMap.of(
+                "com.palantir:test:1.0.0", ImmutableList.of(firstSchema, secondSchema)));
+        String secondMarkdown = MarkdownRenderer.render("com.palantir:test", ImmutableMap.of(
+                "com.palantir:test:1.0.0",
+                // reverse order should produce the same results
+                ImmutableList.of(secondSchema, firstSchema)));
+        assertThat(firstMarkdown)
+                .isEqualTo("# Metrics\n"
+                        + "\n"
+                        + "## Test\n"
+                        + "\n"
+                        + "`com.palantir:test:1.0.0`\n"
+                        + "\n"
+                        + "### anamespace\n"
+                        + "namespace docs\n"
+                        + "- `anamespace.metric` (meter): metric docs\n"
+                        + "\n"
+                        + "### namespace\n"
+                        + "namespace docs\n"
+                        + "- `namespace.metric` (meter): metric docs\n"
+                        + "\n"
+                        + "### secondSchema\n"
+                        + "namespace docs\n"
+                        + "- `secondSchema.metric` (meter): metric docs")
+                .isEqualTo(secondMarkdown);
     }
 
     @Test


### PR DESCRIPTION
==COMMIT_MSG==
Stable markdown order regardless of the input schema order. Prevents failing checks due to build order differences.
==COMMIT_MSG==