### PR TITLE
Provide stable markdown order when a namespace is defined twice

### DIFF
--- a/changelog/@unreleased/pr-28.v2.yml
+++ b/changelog/@unreleased/pr-28.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Provide stable markdown order when a namespace is defined twice
+  links:
+  - https://github.com/palantir/metric-schema/pull/28

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -21,6 +21,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.palantir.metric.schema.MetricDefinition;
+import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
 import java.util.Comparator;
 import java.util.List;
@@ -89,7 +90,13 @@ public final class MarkdownRenderer {
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
                                 .flatMap(schema -> schema.getNamespaces().entrySet().stream())
-                                .sorted(Map.Entry.comparingByKey())
+                                // Break ties on the namespace name using the number of metrics, then MetricNamespace
+                                // hashCode value.
+                                .sorted(Map.Entry.<String, MetricNamespace>comparingByKey()
+                                        .thenComparing(Map.Entry.comparingByValue(
+                                                Comparator.comparing(ns -> ns.getMetrics().size())))
+                                        .thenComparing(Map.Entry.comparingByValue(
+                                                Comparator.comparing(MetricNamespace::hashCode))))
                                 .map(schemaEntry -> Namespace.builder()
                                         .name(schemaEntry.getKey())
                                         .definition(schemaEntry.getValue())

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -90,11 +90,13 @@ public final class MarkdownRenderer {
                         .sourceCoordinates(entry.getKey())
                         .namespaces(entry.getValue().stream()
                                 .flatMap(schema -> schema.getNamespaces().entrySet().stream())
-                                // Break ties on the namespace name using the number of metrics, then MetricNamespace
-                                // hashCode value.
+                                // Break ties on the namespace name using the documentation, number of metrics, then
+                                // MetricNamespace hashCode.
                                 .sorted(Map.Entry.<String, MetricNamespace>comparingByKey()
                                         .thenComparing(Map.Entry.comparingByValue(
-                                                Comparator.comparing(ns -> ns.getMetrics().size())))
+                                                Comparator.comparing(namespace -> namespace.getDocs().get())))
+                                        .thenComparing(Map.Entry.comparingByValue(
+                                                Comparator.comparing(namespace -> namespace.getMetrics().size())))
                                         .thenComparing(Map.Entry.comparingByValue(
                                                 Comparator.comparing(MetricNamespace::hashCode))))
                                 .map(schemaEntry -> Namespace.builder()


### PR DESCRIPTION
This occurs when projects use package private generated utilities
and must split a namespace to avoid leaking utilities into public
API.

==COMMIT_MSG==
Provide stable markdown order when a namespace is defined twice
==COMMIT_MSG==