### PR TITLE
Fix markdown rendering sort order to prioritize local metrics

### DIFF
--- a/changelog/@unreleased/pr-43.v2.yml
+++ b/changelog/@unreleased/pr-43.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix markdown rendering sort order to prioritize local metrics
+  links:
+  - https://github.com/palantir/metric-schema/pull/43

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -142,23 +142,24 @@ public final class MarkdownRenderer {
      * Comparator which prefers sections from the local projects group. Metrics defined in the local project should be
      * rendered first.
      */
-    private static final class CoordinateComparator implements Comparator<String> {
+    @VisibleForTesting
+    static final class CoordinateComparator implements Comparator<String> {
 
-        private final String localCoordinate;
+        private final String localGroup;
 
         CoordinateComparator(String localCoordinate) {
-            this.localCoordinate = localCoordinate;
+            this.localGroup = getGroup(localCoordinate);
         }
 
         @Override
         public int compare(String first, String second) {
             String firstGroup = getGroup(first);
             String secondGroup = getGroup(second);
-            if (Objects.equals(firstGroup, localCoordinate) || Objects.equals(secondGroup, localCoordinate)) {
+            if (Objects.equals(firstGroup, localGroup) || Objects.equals(secondGroup, localGroup)) {
                 if (Objects.equals(firstGroup, secondGroup)) {
                     return 0;
                 }
-                return Objects.equals(firstGroup, localCoordinate) ? -1 : 1;
+                return Objects.equals(firstGroup, localGroup) ? -1 : 1;
             }
             return first.compareTo(second);
         }

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -155,10 +155,8 @@ public final class MarkdownRenderer {
         public int compare(String first, String second) {
             String firstGroup = getGroup(first);
             String secondGroup = getGroup(second);
-            if (Objects.equals(firstGroup, localGroup) || Objects.equals(secondGroup, localGroup)) {
-                if (Objects.equals(firstGroup, secondGroup)) {
-                    return 0;
-                }
+            if (!Objects.equals(firstGroup, secondGroup)
+                    && (Objects.equals(firstGroup, localGroup) || Objects.equals(secondGroup, localGroup))) {
                 return Objects.equals(firstGroup, localGroup) ? -1 : 1;
             }
             return first.compareTo(second);

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -260,5 +260,11 @@ class MarkdownRendererTest {
         assertThat("com.palantir.foo:name")
                 .usingComparator(new MarkdownRenderer.CoordinateComparator("com.palantir.foo:name2"))
                 .isLessThan("com.palantir.bar:name");
+        assertThat("com.palantir.foo:a")
+                .usingComparator(new MarkdownRenderer.CoordinateComparator("com.palantir.foo:any"))
+                .isLessThan("com.palantir.foo:b");
+        assertThat("com.palantir.foo:b")
+                .usingComparator(new MarkdownRenderer.CoordinateComparator("com.palantir.foo:any"))
+                .isGreaterThan("com.palantir.foo:a");
     }
 }

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -251,4 +251,14 @@ class MarkdownRendererTest {
         assertThat(MarkdownRenderer.displayName("bar-baz")).isEqualTo("Bar Baz");
         assertThat(MarkdownRenderer.displayName("bar.baz")).isEqualTo("Bar Baz");
     }
+
+    @Test
+    void testCoordinateComparator() {
+        assertThat("com.palantir.foo:name")
+                .usingComparator(new MarkdownRenderer.CoordinateComparator("com.unknown:name"))
+                .isGreaterThan("com.palantir.bar:name");
+        assertThat("com.palantir.foo:name")
+                .usingComparator(new MarkdownRenderer.CoordinateComparator("com.palantir.foo:name2"))
+                .isLessThan("com.palantir.bar:name");
+    }
 }


### PR DESCRIPTION
Fixes a bug in the markdown renderer which compared artifact
groups to full coordinates.
In the future we shouldn't validate using projects with names
beginning with 'a'. oops!

## After this PR
==COMMIT_MSG==
Fix markdown rendering sort order to prioritize local metrics
==COMMIT_MSG==

## Possible downsides?
none.