### PR TITLE
correctly set project group and name as inputs to generateMetricMarkdown

### DIFF
--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: correctly set project group and name as inputs to `generateMetricMarkdown`
+  links:
+  - https://github.com/palantir/metric-schema/pull/93


### PR DESCRIPTION
## Before this PR
Ran into some issues when rename a project

## After this PR
==COMMIT_MSG==
correctly set project group and name as inputs to `generateMetricMarkdown`
==COMMIT_MSG==

## Possible downsides?
N/A