### PR TITLE
Make builders "strict"

### DIFF
--- a/changelog/@unreleased/pr-227.v2.yml
+++ b/changelog/@unreleased/pr-227.v2.yml
@@ -1,0 +1,19 @@
+type: improvement
+improvement:
+  description: |-
+    Make builders "strict"
+
+    ## Before this PR
+    You can hold onto an earlier builder state and re-finish building the metric differently.
+
+    If a consumer doesn't realize that there's only one object implementing all stages and assumes that they can reuse a half built builder, certain usages will corrupt themselves.
+
+    Generally, folks (e.g. @carterkozak :) ) are nervous that people could cause issues by holding onto a builder.
+
+    ## After this PR
+    That's no longer possible. You can only mutate each step of a builder once.
+
+    ## Possible downsides?
+    If someone is already doing the above, it will now throw. Odds are that if they're doing that, it's already buggy, but it's theoretically possible to have done it safely.
+  links:
+  - https://github.com/palantir/metric-schema/pull/227

--- a/changelog/@unreleased/pr-227.v2.yml
+++ b/changelog/@unreleased/pr-227.v2.yml
@@ -1,19 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Make builders "strict"
-
-    ## Before this PR
-    You can hold onto an earlier builder state and re-finish building the metric differently.
-
-    If a consumer doesn't realize that there's only one object implementing all stages and assumes that they can reuse a half built builder, certain usages will corrupt themselves.
-
-    Generally, folks (e.g. @carterkozak :) ) are nervous that people could cause issues by holding onto a builder.
-
-    ## After this PR
-    That's no longer possible. You can only mutate each step of a builder once.
-
-    ## Possible downsides?
-    If someone is already doing the above, it will now throw. Odds are that if they're doing that, it's already buggy, but it's theoretically possible to have done it safely.
+    Staged builders are now "strict" in that a field can't be mutated once it's set, and an earlier state of a builder can't be reused. This eliminates a class of buggy misuse.
   links:
   - https://github.com/palantir/metric-schema/pull/227

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -69,12 +69,14 @@ public final class MyNamespaceMetrics {
 
         @Override
         public ResponseSizeBuilder serviceName(String serviceName) {
+            Preconditions.checkState(this.serviceName == null, "service-name is already set");
             this.serviceName = Preconditions.checkNotNull(serviceName, "service-name is required");
             return this;
         }
 
         @Override
         public ResponseSizeBuilder endpoint(String endpoint) {
+            Preconditions.checkState(this.endpoint == null, "endpoint is already set");
             this.endpoint = Preconditions.checkNotNull(endpoint, "endpoint is required");
             return this;
         }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -90,18 +90,21 @@ public final class ReservedConflictMetrics {
 
         @Override
         public IntBuilder int_(String int_) {
+            Preconditions.checkState(this.int_ == null, "int is already set");
             this.int_ = Preconditions.checkNotNull(int_, "int is required");
             return this;
         }
 
         @Override
         public IntBuilder registry_(String registry_) {
+            Preconditions.checkState(this.registry_ == null, "registry is already set");
             this.registry_ = Preconditions.checkNotNull(registry_, "registry is required");
             return this;
         }
 
         @Override
         public IntBuilder long_(String long_) {
+            Preconditions.checkState(this.long_ == null, "long is already set");
             this.long_ = Preconditions.checkNotNull(long_, "long is required");
             return this;
         }
@@ -130,6 +133,7 @@ public final class ReservedConflictMetrics {
 
         @Override
         public DoubleBuilder int_(String int_) {
+            Preconditions.checkState(this.int_ == null, "int is already set");
             this.int_ = Preconditions.checkNotNull(int_, "int is required");
             return this;
         }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -66,12 +66,14 @@ public final class ServerMetrics {
 
         @Override
         public ResponseSizeBuilder serviceName(String serviceName) {
+            Preconditions.checkState(this.serviceName == null, "service-name is already set");
             this.serviceName = Preconditions.checkNotNull(serviceName, "service-name is required");
             return this;
         }
 
         @Override
         public ResponseSizeBuilder endpoint(String endpoint) {
+            Preconditions.checkState(this.endpoint == null, "endpoint is already set");
             this.endpoint = Preconditions.checkNotNull(endpoint, "endpoint is required");
             return this;
         }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -64,12 +64,14 @@ final class VisibilityMetrics {
 
         @Override
         public ComplexBuilder foo(String foo) {
+            Preconditions.checkState(this.foo == null, "foo is already set");
             this.foo = Preconditions.checkNotNull(foo, "foo is required");
             return this;
         }
 
         @Override
         public ComplexBuilder bar(String bar) {
+            Preconditions.checkState(this.bar == null, "bar is already set");
             this.bar = Preconditions.checkNotNull(bar, "bar is required");
             return this;
         }

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -218,6 +218,11 @@ final class UtilityGenerator {
                                 .returns(ClassName.bestGuess(Custodian.anyToUpperCamel(metricName) + "Builder"))
                                 .addParameter(String.class, Custodian.sanitizeName(tag))
                                 .addStatement(
+                                        "$1T.checkState(this.$2L == null, $3S)",
+                                        Preconditions.class,
+                                        Custodian.sanitizeName(tag),
+                                        tag + " is already set")
+                                .addStatement(
                                         "this.$1L = $2T.checkNotNull($1L, $3S)",
                                         Custodian.sanitizeName(tag),
                                         Preconditions.class,


### PR DESCRIPTION
## Before this PR
You can hold onto an earlier builder state and re-finish building the metric differently.

If a consumer doesn't realize that there's only one object implementing all stages and assumes that they can reuse a half built builder, certain usages will corrupt themselves.

Generally, folks (e.g. @carterkozak :) ) are nervous that people could cause issues by holding onto a builder.

## After this PR
That's no longer possible. You can only mutate each step of a builder once.

## Possible downsides?
If someone is already doing the above, it will now throw. Odds are that if they're doing that, it's already buggy, but it's theoretically possible to have done it safely.