### PR TITLE
fix #270: Add missing validation to the metric-schema parser

### DIFF
--- a/changelog/@unreleased/pr-271.v2.yml
+++ b/changelog/@unreleased/pr-271.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: Add missing validation to the metric-schema parser. Validation was
+    dropped incorrectly, so it's possible some metric names will need to be updated.
+    Our current pipelines don't differentiate between hyphens and underscores so it's
+    safe to replace underscores with hyphens.
+  links:
+  - https://github.com/palantir/metric-schema/pull/271

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
@@ -81,7 +81,8 @@ final class Validator {
                 .ifPresent(shortName -> Preconditions.checkArgument(
                         SHORT_NAME_PREDICATE.matcher(shortName).matches(),
                         "ShortName must match pattern",
-                        SafeArg.of("pattern", SHORT_NAME_PATTERN)));
+                        SafeArg.of("pattern", SHORT_NAME_PATTERN),
+                        SafeArg.of("invalidShortName", shortName)));
     }
 
     private static void validateDocumentation(Documentation documentation) {

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
@@ -47,12 +47,14 @@ final class Validator {
         validateShortName(namespaceValue);
         validateDocumentation(namespaceValue.getDocs());
         namespaceValue.getMetrics().forEach((name, definition) -> {
+            Preconditions.checkNotNull(definition, "MetricDefinition is required", SafeArg.of("namespace", namespace));
             Preconditions.checkArgument(
                     !name.isEmpty(), "MetricDefinition names must not be empty", SafeArg.of("namespace", namespace));
             Preconditions.checkArgument(
                     NAME_PREDICATE.matcher(name).matches(),
                     "MetricDefinition names must match pattern",
-                    SafeArg.of("pattern", NAME_PATTERN));
+                    SafeArg.of("pattern", NAME_PATTERN),
+                    SafeArg.of("invalidTagName", name));
             Preconditions.checkArgument(
                     MetricType.Value.UNKNOWN != definition.getType().get(),
                     "Unknown metric type",

--- a/metric-schema-java/src/test/resources/long-namespace.yml
+++ b/metric-schema-java/src/test/resources/long-namespace.yml
@@ -1,6 +1,6 @@
 namespaces:
   com.palantir.very.long.namespace:
-    shortName: myNamespace
+    shortName: MyNamespace
     docs: General web server metrics.
     metrics:
       response.size:


### PR DESCRIPTION
## Before this PR
no validation!?

## After this PR
==COMMIT_MSG==
Add missing validation to the metric-schema parser. Validation was dropped incorrectly, so it's possible some metric names will need to be updated. Our current pipelines don't differentiate between hyphens and underscores so it's safe to replace underscores with hyphens.
==COMMIT_MSG==

## Possible downsides?
Validation was dropped incorrectly, so it's possible some metric names will need to be updated. Our current pipelines don't differentiate between hyphens and underscores so it's safe to replace underscores with hyphens.