### PR TITLE
fix #274: Relax metric name validation

### DIFF
--- a/changelog/@unreleased/pr-275.v2.yml
+++ b/changelog/@unreleased/pr-275.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Relax metric name validation
+  links:
+  - https://github.com/palantir/metric-schema/pull/275

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 final class Validator {
 
     private static final String SHORT_NAME_PATTERN = "[A-Z][a-zA-Z0-9]+";
-    private static final String NAME_SEGMENT_PATTERN = "[a-z][a-zA-Z0-9\\-]+";
+    private static final String NAME_SEGMENT_PATTERN = "[a-z0-9][a-zA-Z0-9\\-]*";
     private static final String NAME_PATTERN = "(" + NAME_SEGMENT_PATTERN + "\\.)*" + NAME_SEGMENT_PATTERN;
     private static final Pattern NAME_PREDICATE = Pattern.compile(NAME_PATTERN);
     private static final Pattern SHORT_NAME_PREDICATE = Pattern.compile(SHORT_NAME_PATTERN);

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/ValidatorTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/ValidatorTest.java
@@ -17,6 +17,7 @@
 package com.palantir.metric.schema;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.jupiter.api.Test;
@@ -178,5 +179,23 @@ class ValidatorTest {
                         .build()))
                 .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("ShortName must match pattern");
+    }
+
+    @Test
+    void testMetricNameWithNumbers() {
+        assertThatCode(() -> Validator.validate(MetricSchema.builder()
+                        .namespaces(
+                                "os",
+                                MetricNamespace.builder()
+                                        .docs(DOCS)
+                                        .metrics(
+                                                "load.1",
+                                                MetricDefinition.builder()
+                                                        .docs(DOCS)
+                                                        .type(MetricType.GAUGE)
+                                                        .build())
+                                        .build())
+                        .build()))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
==COMMIT_MSG==
Relax metric name validation
==COMMIT_MSG==

See https://github.com/palantir/tritium/pull/741#issuecomment-639921046