### PR TITLE
Allow last segment of a namespace to start with an uppercase

### DIFF
--- a/changelog/@unreleased/pr-282.v2.yml
+++ b/changelog/@unreleased/pr-282.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow last segment of a namespace to start with an uppercase
+  links:
+  - https://github.com/palantir/metric-schema/pull/282<S-F7>

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Validator.java
@@ -25,7 +25,8 @@ final class Validator {
 
     private static final String SHORT_NAME_PATTERN = "[A-Z][a-zA-Z0-9]+";
     private static final String NAME_SEGMENT_PATTERN = "[a-z0-9][a-zA-Z0-9\\-]*";
-    private static final String NAME_PATTERN = "(" + NAME_SEGMENT_PATTERN + "\\.)*" + NAME_SEGMENT_PATTERN;
+    private static final String LAST_NAME_SEGMENT_PATTERN = "[a-zA-Z0-9][a-zA-Z0-9\\-]*";
+    private static final String NAME_PATTERN = "(" + NAME_SEGMENT_PATTERN + "\\.)*" + LAST_NAME_SEGMENT_PATTERN;
     private static final Pattern NAME_PREDICATE = Pattern.compile(NAME_PATTERN);
     private static final Pattern SHORT_NAME_PREDICATE = Pattern.compile(SHORT_NAME_PATTERN);
 

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/ValidatorTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/ValidatorTest.java
@@ -168,6 +168,13 @@ class ValidatorTest {
     }
 
     @Test
+    void testLastSegmentStartsWithUppercase() {
+        Validator.validate(MetricSchema.builder()
+                .namespaces("test0.Test", MetricNamespace.builder().docs(DOCS).build())
+                .build());
+    }
+
+    @Test
     void testLowerCamelShortName() {
         assertThatThrownBy(() -> Validator.validate(MetricSchema.builder()
                         .namespaces(


### PR DESCRIPTION
## Before this PR

Namespaces of the form `com.company.ClassName` are disallowed starting in 0.5.4. We recently migrated to metric-schema and metrics of that form prior to the migration. It would be nice to allow such metric names to avoid breaks.

## After this PR
==COMMIT_MSG==
Allow last segment of a namespace to start with an uppercase
==COMMIT_MSG==

cc @carterkozak