### PR TITLE
Don't implicitly run generateMetricsMarkdown when writing locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ after metrics are generated, IntelliJ IDEA users can run the `idea` task.
 ```
 
 Metric documentation is updated using the `generateMetricsMarkdown` gradle task or by running 
-`./gradlew --write-locks`. The gradle plugin will ensure that the metrics markdown is always up to date.
+`./gradlew generateMetricsMarkdown --write-locks`. The gradle plugin will ensure that the metrics markdown is always up to date.
 
 All metric definitions will be embedded within the output JAR as a resource located `metric-schema/metrics.json`.
 

--- a/changelog/@unreleased/pr-283.v2.yml
+++ b/changelog/@unreleased/pr-283.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Running `./gradlew --write-locks` no longer runs `generateMetricsMarkdown`
+    implicitly. To update your generated markdown, you need to run `./gradlew generateMetricsMarkdown
+    --write-locks` explicitly.
+  links:
+  - https://github.com/palantir/metric-schema/pull/283

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
@@ -16,9 +16,6 @@
 
 package com.palantir.metric.schema.gradle;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import org.gradle.StartParameter;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskProvider;
@@ -41,16 +38,5 @@ public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
                     task.dependsOn(createMetricsManifest);
                 });
         project.getTasks().named("check", check -> check.dependsOn(generateMetricsMarkdown));
-
-        // Wire up dependencies so running `./gradlew --write-locks` will update the markdown
-        StartParameter startParam = project.getGradle().getStartParameter();
-        if (startParam.isWriteDependencyLocks()
-                && !startParam.getTaskNames().contains(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN)) {
-            List<String> taskNames = ImmutableList.<String>builder()
-                    .addAll(startParam.getTaskNames())
-                    .add(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN)
-                    .build();
-            startParam.setTaskNames(taskNames);
-        }
     }
 }

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
@@ -60,7 +60,7 @@ class GenerateMetricMarkdownIntegrationSpec extends IntegrationSpec {
         file('src/main/metrics/metrics.yml') << METRICS
 
         then:
-        def result = runTasksSuccessfully('--write-locks')
+        def result = runTasksSuccessfully(':generateMetricsMarkdown', '--write-locks')
         result.wasExecuted(':generateMetricsMarkdown')
         fileExists("metrics.md")
     }
@@ -80,7 +80,7 @@ class GenerateMetricMarkdownIntegrationSpec extends IntegrationSpec {
         file('src/main/metrics/metrics.yml') << METRICS
 
         then:
-        def result1 = runTasksSuccessfully('--write-locks')
+        def result1 = runTasksSuccessfully(':generateMetricsMarkdown', '--write-locks')
         result1.wasExecuted(':generateMetricsMarkdown')
         fileExists("metrics.md")
 


### PR DESCRIPTION
Similar to https://github.com/palantir/gradle-baseline/pull/1389.

## Before this PR
Running `./gradlew --write-locks` triggers `generateMetricsMarkdown` which requires compiling all projects that are dependencies of the distribution project.

## After this PR
Running `./gradlew --write-locks` does not trigger `generateMetricsMarkdown`. To update the generated markdown users need to run `./gradlew generateMetricsMarkdown --write-locks` explicitly.