### PR TITLE
metric-schema embeds libraryName & libraryVersion tags into all metrics

### DIFF
--- a/changelog/@unreleased/pr-288.v2.yml
+++ b/changelog/@unreleased/pr-288.v2.yml
@@ -1,0 +1,9 @@
+type: feature
+feature:
+  description: Generated code now includes a libraryName and libraryVersion tag in
+    all metrics, to help attribute fleet wide cost to particular libraries. This uses
+    a libraryName derived from the gradle `rootProject.name` by default, although
+    this can be overridden on the `generateMetricSchema` task if desired. (Setting
+    it to `null` turns off the tag entirely).
+  links:
+  - https://github.com/palantir/metric-schema/pull/288

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -5,9 +5,16 @@ import com.codahale.metrics.Histogram;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Optional;
 
 /** General web server metrics. */
 public final class MyNamespaceMetrics {
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION =
+            Optional.ofNullable(MyNamespaceMetrics.class.getPackage().getImplementationVersion())
+                    .orElse("unknown");
+
     private final TaggedMetricRegistry registry;
 
     private MyNamespaceMetrics(TaggedMetricRegistry registry) {
@@ -28,6 +35,8 @@ public final class MyNamespaceMetrics {
         registry.registerWithReplacement(
                 MetricName.builder()
                         .safeName("com.palantir.very.long.namespace.worker.utilization")
+                        .putSafeTags("libraryName", LIBRARY_NAME)
+                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
                         .build(),
                 gauge);
     }
@@ -64,6 +73,8 @@ public final class MyNamespaceMetrics {
                             .safeName("com.palantir.very.long.namespace.response.size")
                             .putSafeTags("service-name", serviceName)
                             .putSafeTags("endpoint", endpoint)
+                            .putSafeTags("libraryName", LIBRARY_NAME)
+                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build());
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -6,9 +6,17 @@ import com.codahale.metrics.Meter;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Optional;
 
 /** Tests that reserved words are escaped. */
 public final class ReservedConflictMetrics {
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION =
+            Optional.ofNullable(
+                            ReservedConflictMetrics.class.getPackage().getImplementationVersion())
+                    .orElse("unknown");
+
     private final TaggedMetricRegistry registry;
 
     private ReservedConflictMetrics(TaggedMetricRegistry registry) {
@@ -31,13 +39,20 @@ public final class ReservedConflictMetrics {
                 MetricName.builder()
                         .safeName("reserved.conflict.long")
                         .putSafeTags("int", int_)
+                        .putSafeTags("libraryName", LIBRARY_NAME)
+                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
                         .build());
     }
 
     /** Gauge metric with a single no tags. */
     public void float_(Gauge<?> gauge) {
         registry.registerWithReplacement(
-                MetricName.builder().safeName("reserved.conflict.float").build(), gauge);
+                MetricName.builder()
+                        .safeName("reserved.conflict.float")
+                        .putSafeTags("libraryName", LIBRARY_NAME)
+                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                        .build(),
+                gauge);
     }
 
     /** Gauge metric with a single tag. */
@@ -85,6 +100,8 @@ public final class ReservedConflictMetrics {
                             .putSafeTags("int", int_)
                             .putSafeTags("registry", registry_)
                             .putSafeTags("long", long_)
+                            .putSafeTags("libraryName", LIBRARY_NAME)
+                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build());
         }
 
@@ -127,6 +144,8 @@ public final class ReservedConflictMetrics {
                     MetricName.builder()
                             .safeName("reserved.conflict.double")
                             .putSafeTags("int", int_)
+                            .putSafeTags("libraryName", LIBRARY_NAME)
+                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build(),
                     gauge);
         }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -5,9 +5,16 @@ import com.codahale.metrics.Histogram;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Optional;
 
 /** General web server metrics. */
 public final class ServerMetrics {
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION =
+            Optional.ofNullable(ServerMetrics.class.getPackage().getImplementationVersion())
+                    .orElse("unknown");
+
     private final TaggedMetricRegistry registry;
 
     private ServerMetrics(TaggedMetricRegistry registry) {
@@ -26,7 +33,12 @@ public final class ServerMetrics {
     /** A gauge of the ratio of active workers to the number of workers. */
     public void workerUtilization(Gauge<?> gauge) {
         registry.registerWithReplacement(
-                MetricName.builder().safeName("server.worker.utilization").build(), gauge);
+                MetricName.builder()
+                        .safeName("server.worker.utilization")
+                        .putSafeTags("libraryName", LIBRARY_NAME)
+                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                        .build(),
+                gauge);
     }
 
     @Override
@@ -61,6 +73,8 @@ public final class ServerMetrics {
                             .safeName("server.response.size")
                             .putSafeTags("service-name", serviceName)
                             .putSafeTags("endpoint", endpoint)
+                            .putSafeTags("libraryName", LIBRARY_NAME)
+                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build());
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -5,9 +5,16 @@ import com.codahale.metrics.Gauge;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Optional;
 
 /** Tests we respect javaVisibility */
 final class VisibilityMetrics {
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION =
+            Optional.ofNullable(VisibilityMetrics.class.getPackage().getImplementationVersion())
+                    .orElse("unknown");
+
     private final TaggedMetricRegistry registry;
 
     private VisibilityMetrics(TaggedMetricRegistry registry) {
@@ -20,7 +27,12 @@ final class VisibilityMetrics {
 
     /** just a metric */
     Counter test() {
-        return registry.counter(MetricName.builder().safeName("visibility.test").build());
+        return registry.counter(
+                MetricName.builder()
+                        .safeName("visibility.test")
+                        .putSafeTags("libraryName", LIBRARY_NAME)
+                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                        .build());
     }
 
     /** Tagged gauge metric. */
@@ -58,6 +70,8 @@ final class VisibilityMetrics {
                             .safeName("visibility.complex")
                             .putSafeTags("foo", foo)
                             .putSafeTags("bar", bar)
+                            .putSafeTags("libraryName", LIBRARY_NAME)
+                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build(),
                     gauge);
         }

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
@@ -34,9 +34,14 @@ public final class JavaGenerator {
     public static List<Path> generate(JavaGeneratorArgs args) {
         return args.inputs().stream()
                 .map(SchemaParser.get()::parseFile)
-                .flatMap(schema -> schema.getNamespaces().entrySet().stream()
-                        .map(entry -> UtilityGenerator.generateUtilityClass(
-                                entry.getKey(), entry.getValue(), getPackage(args, schema), getVisibility(schema))))
+                .flatMap(schema -> schema.getNamespaces().entrySet().stream().map(entry -> {
+                    return UtilityGenerator.generateUtilityClass(
+                            entry.getKey(),
+                            entry.getValue(),
+                            args.libraryName(),
+                            getPackage(args, schema),
+                            getVisibility(schema));
+                }))
                 .map(javaFile -> Goethe.formatAndEmit(javaFile, args.output()))
                 .collect(ImmutableList.toImmutableList());
     }

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
@@ -23,12 +23,14 @@ import javax.lang.model.SourceVersion;
 /** Field and parameter names used by this generator. */
 final class ReservedNames {
 
+    static final String LIBRARY_NAME = "LIBRARY_NAME";
+    static final String LIBRARY_VERSION = "LIBRARY_VERSION";
     static final String FACTORY_METHOD = "of";
     static final String GAUGE_NAME = "gauge";
     static final String REGISTRY_NAME = "registry";
 
     private static final ImmutableSet<String> RESERVED_NAMES =
-            ImmutableSet.of(FACTORY_METHOD, GAUGE_NAME, REGISTRY_NAME);
+            ImmutableSet.of(FACTORY_METHOD, GAUGE_NAME, REGISTRY_NAME, LIBRARY_NAME, LIBRARY_VERSION);
 
     /** Returns true if the input string cannot be used. */
     static boolean isValid(String input) {

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/JavaGeneratorTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/JavaGeneratorTest.java
@@ -43,6 +43,7 @@ public class JavaGeneratorTest {
                         .output(tempDir)
                         .inputs(listFiles(Paths.get("src/test/resources")))
                         .defaultPackageName("com.palantir.test")
+                        .libraryName("witchcraft")
                         .build())
                 .stream()
                 .map(tempDir::relativize)


### PR DESCRIPTION
## Before this PR

This has the same motivation as https://github.com/palantir/tritium/pull/754, just an alternative implementation approach which is probably easier to roll out.

> In Dialogue, I've found it incredibly beneficial to have the dialogueVersion tag on all my metrics, because when looking at a graph I can tell whether they're on latest or an older version. I've been using this VersionedTaggedMetricRegistry class to achieve this: https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/java/com/palantir/dialogue/core/VersionedTaggedMetricRegistry.java. I had intended to generalize this and make the pattern available for other libraries e.g. atlasdb (cc @jkong) and witchcraft.
>
> A more urgent reason to pursue this came up recently with regard to our DD $ spend, as our spend reports are currently broken down by product tag, which makes it hard to see what proportion of the $ spend our various libraries are responsible for. Apparently we can get cost breakdowns made for any given tag, there just isn't a consistent one across libraries yet. (cc @samrogerson)

## After this PR
==COMMIT_MSG==
Generated code now includes a libraryName and libraryVersion tag in all metrics, to help attribute fleet wide cost to particular libraries. This uses a libraryName derived from the gradle `rootProject.name` by default, although this can be overridden on the `generateMetricSchema` task if desired. (Setting it to `null` turns off the tag entirely).
==COMMIT_MSG==

cc @tpetracca who slacked me about this

## Possible downsides?

note - this PR doesn't currently include these `libraryName` or `libraryVersion` tags in the json / markdown.... is this important??
<!-- Please describe any way users could be negatively affected by this PR. -->