### PR TITLE
Getters for gauge metric names

### DIFF
--- a/changelog/@unreleased/pr-293.v2.yml
+++ b/changelog/@unreleased/pr-293.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: For any gauges defined in metric-schema, there are now methods that
+    allow getting the raw `MetricName` (either via the staged builder or directly)
+  links:
+  - https://github.com/palantir/metric-schema/pull/293

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -32,13 +32,15 @@ public final class MyNamespaceMetrics {
 
     /** A gauge of the ratio of active workers to the number of workers. */
     public void workerUtilization(Gauge<?> gauge) {
-        registry.registerWithReplacement(
-                MetricName.builder()
-                        .safeName("com.palantir.very.long.namespace.worker.utilization")
-                        .putSafeTags("libraryName", LIBRARY_NAME)
-                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                        .build(),
-                gauge);
+        registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
+    }
+
+    public MetricName workerUtilizationMetricName() {
+        return MetricName.builder()
+                .safeName("com.palantir.very.long.namespace.worker.utilization")
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .build();
     }
 
     @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -46,13 +46,15 @@ public final class ReservedConflictMetrics {
 
     /** Gauge metric with a single no tags. */
     public void float_(Gauge<?> gauge) {
-        registry.registerWithReplacement(
-                MetricName.builder()
-                        .safeName("reserved.conflict.float")
-                        .putSafeTags("libraryName", LIBRARY_NAME)
-                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                        .build(),
-                gauge);
+        registry.registerWithReplacement(floatMetricName(), gauge);
+    }
+
+    public MetricName floatMetricName() {
+        return MetricName.builder()
+                .safeName("reserved.conflict.float")
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .build();
     }
 
     /** Gauge metric with a single tag. */

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -129,6 +129,8 @@ public final class ReservedConflictMetrics {
 
     public interface DoubleBuildStage {
         void build(Gauge<?> gauge);
+
+        MetricName buildMetricName();
     }
 
     public interface DoubleBuilderIntStage {
@@ -148,6 +150,16 @@ public final class ReservedConflictMetrics {
                             .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build(),
                     gauge);
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("reserved.conflict.double")
+                    .putSafeTags("int", int_)
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .build();
         }
 
         @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -144,14 +144,7 @@ public final class ReservedConflictMetrics {
 
         @Override
         public void build(Gauge<?> gauge) {
-            registry.registerWithReplacement(
-                    MetricName.builder()
-                            .safeName("reserved.conflict.double")
-                            .putSafeTags("int", int_)
-                            .putSafeTags("libraryName", LIBRARY_NAME)
-                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                            .build(),
-                    gauge);
+            registry.registerWithReplacement(buildMetricName(), gauge);
         }
 
         @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -32,13 +32,15 @@ public final class ServerMetrics {
 
     /** A gauge of the ratio of active workers to the number of workers. */
     public void workerUtilization(Gauge<?> gauge) {
-        registry.registerWithReplacement(
-                MetricName.builder()
-                        .safeName("server.worker.utilization")
-                        .putSafeTags("libraryName", LIBRARY_NAME)
-                        .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                        .build(),
-                gauge);
+        registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
+    }
+
+    public MetricName workerUtilizationMetricName() {
+        return MetricName.builder()
+                .safeName("server.worker.utilization")
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .build();
     }
 
     @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -67,15 +67,7 @@ final class VisibilityMetrics {
 
         @Override
         public void build(Gauge<?> gauge) {
-            registry.registerWithReplacement(
-                    MetricName.builder()
-                            .safeName("visibility.complex")
-                            .putSafeTags("foo", foo)
-                            .putSafeTags("bar", bar)
-                            .putSafeTags("libraryName", LIBRARY_NAME)
-                            .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                            .build(),
-                    gauge);
+            registry.registerWithReplacement(buildMetricName(), gauge);
         }
 
         @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -47,6 +47,8 @@ final class VisibilityMetrics {
 
     interface ComplexBuildStage {
         void build(Gauge<?> gauge);
+
+        MetricName buildMetricName();
     }
 
     interface ComplexBuilderFooStage {
@@ -74,6 +76,17 @@ final class VisibilityMetrics {
                             .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build(),
                     gauge);
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("visibility.complex")
+                    .putSafeTags("foo", foo)
+                    .putSafeTags("bar", bar)
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .build();
         }
 
         @Override

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -240,10 +240,10 @@ final class UtilityGenerator {
                     // TODO(ckozak): Update to use a method which can log a warning and replace existing gauges.
                     // See MetricRegistries.registerWithReplacement.
                     .addStatement(
-                            "$L.$L($L, $L)",
+                            "$L.$L($L(), $L)",
                             ReservedNames.REGISTRY_NAME,
                             metricRegistryMethod,
-                            metricNameBlock,
+                            buildMetricName.name,
                             ReservedNames.GAUGE_NAME);
         } else {
             buildMethodBuilder.addStatement(


### PR DESCRIPTION
## Before this PR

Occasionally, people need to interact with a metric name in a way not prescribed by metric-schema. For example, in dialogue we have the `DialogueInternalWeakReducingGauge` thing https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueInternalWeakReducingGauge.java#L64 and in WC.

## After this PR
==COMMIT_MSG==
For any gauges defined in metric-schema, there are now methods that allow getting the raw `MetricName` (either via the staged builder or directly)
==COMMIT_MSG==

cc @carterkozak 

## Possible downsides?

- this could open the door for people to start registering metrics in funky ways. My hope is that by keeping this restricted to gauges people won't get _too_ confused.