### PR TITLE
fooMetricName should be static

### DIFF
--- a/changelog/@unreleased/pr-295.v2.yml
+++ b/changelog/@unreleased/pr-295.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `.fooMetricName()` getter method for a gauge `foo` with zero tags
+    can now be accessed statically.
+  links:
+  - https://github.com/palantir/metric-schema/pull/295

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -35,7 +35,7 @@ public final class MyNamespaceMetrics {
         registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
     }
 
-    public MetricName workerUtilizationMetricName() {
+    public static MetricName workerUtilizationMetricName() {
         return MetricName.builder()
                 .safeName("com.palantir.very.long.namespace.worker.utilization")
                 .putSafeTags("libraryName", LIBRARY_NAME)

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -49,7 +49,7 @@ public final class ReservedConflictMetrics {
         registry.registerWithReplacement(floatMetricName(), gauge);
     }
 
-    public MetricName floatMetricName() {
+    public static MetricName floatMetricName() {
         return MetricName.builder()
                 .safeName("reserved.conflict.float")
                 .putSafeTags("libraryName", LIBRARY_NAME)

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -35,7 +35,7 @@ public final class ServerMetrics {
         registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
     }
 
-    public MetricName workerUtilizationMetricName() {
+    public static MetricName workerUtilizationMetricName() {
         return MetricName.builder()
                 .safeName("server.worker.utilization")
                 .putSafeTags("libraryName", LIBRARY_NAME)

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -147,6 +147,7 @@ final class UtilityGenerator {
         CodeBlock metricNameBlock = metricName(namespace, metricName, libraryName, definition.getTags());
         MethodSpec metricNameMethod = MethodSpec.methodBuilder(Custodian.sanitizeName(metricName + "MetricName"))
                 .addModifiers(visibility.apply())
+                .addModifiers(Modifier.STATIC)
                 .returns(MetricName.class)
                 .addCode("return $L;", metricNameBlock)
                 .build();


### PR DESCRIPTION
## Before this PR

I added some methods in 0.5.7 so that it was convenient to access MetricNames for gauges, but I've realised that it presents quite a wonky API. For example, I just wanted to get hold of this MetricName, but I've been forced to pass in a made-up tagged metric registry:

```java
    public static final MetricName WORKER_UTILIZATION_MAX_METRIC_NAME =
            UndertowWorkerMetrics.of(new DefaultTaggedMetricRegistry()).utilizationMaxMetricName();
```

## After this PR
==COMMIT_MSG==
The `.fooMetricName()` getter method for gauges with zero tags can now be accessed statically.
==COMMIT_MSG==

## Possible downsides?
- this makes it a little inconsistent with the other factory methods, which are instance methods