### PR TITLE
improvement: avoid compilation when generating metricsManifest

### DIFF
--- a/changelog/@unreleased/pr-313.v2.yml
+++ b/changelog/@unreleased/pr-313.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: avoid compilation when generating metricsManifest
+  links:
+  - https://github.com/palantir/metric-schema/pull/313

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
@@ -79,8 +79,8 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
         File markdown = outputFile.get().getAsFile();
         File manifest = getManifestFile().getAsFile().get();
 
-        Map<String, List<MetricSchema>> schemas = CreateMetricsManifestTask.mapper.readValue(
-                manifest, new TypeReference<Map<String, List<MetricSchema>>>() {});
+        Map<String, List<MetricSchema>> schemas =
+                ObjectMappers.mapper.readValue(manifest, new TypeReference<Map<String, List<MetricSchema>>>() {});
         if (schemas.isEmpty()) {
             return;
         }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -18,13 +18,10 @@ package com.palantir.metric.schema.gradle;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
-import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.SourceDirectorySet;
@@ -90,17 +87,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                                     ? project.provider(() -> file)
                                     : project.getObjects().fileProperty()));
             task.getOutputFile().set(manifestFile);
-            task.getConfiguration()
-                    .set(project.provider(
-                            () -> CreateMetricsManifestTask.removeProjectDependencies(project, runtimeClasspath)));
-            task.getProjectDependencies()
-                    .set(project.provider(
-                            () -> runtimeClasspath.getIncoming().getResolutionResult().getAllDependencies().stream()
-                                    .map(DependencyResult::getRequested)
-                                    .filter(ProjectComponentSelector.class::isInstance)
-                                    .map(ProjectComponentSelector.class::cast)
-                                    .map(ProjectComponentSelector::getProjectPath)
-                                    .collect(Collectors.toSet())));
+            task.getConfiguration().set(runtimeClasspath);
             task.dependsOn(compileSchemaTask);
         });
     }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -18,9 +18,13 @@ package com.palantir.metric.schema.gradle;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
+import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.SourceDirectorySet;
@@ -75,6 +79,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
             Provider<Directory> metricSchemaDir,
             TaskProvider<CompileMetricSchemaTask> compileSchemaTask) {
         Provider<RegularFile> manifestFile = metricSchemaDir.map(dir -> dir.file("manifest.json"));
+        Configuration runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
         project.getTasks().register(CREATE_METRICS_MANIFEST, CreateMetricsManifestTask.class, task -> {
             // Need to set to empty if compileSchemaTask didn't execute
             task.getMetricsFile()
@@ -85,7 +90,17 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                                     ? project.provider(() -> file)
                                     : project.getObjects().fileProperty()));
             task.getOutputFile().set(manifestFile);
-            task.getConfiguration().set(project.getConfigurations().getByName("runtimeClasspath"));
+            task.getConfiguration()
+                    .set(project.provider(
+                            () -> CreateMetricsManifestTask.removeProjectDependencies(project, runtimeClasspath)));
+            task.getProjectDependencies()
+                    .set(project.provider(
+                            () -> runtimeClasspath.getIncoming().getResolutionResult().getAllDependencies().stream()
+                                    .map(DependencyResult::getRequested)
+                                    .filter(ProjectComponentSelector.class::isInstance)
+                                    .map(ProjectComponentSelector.class::cast)
+                                    .map(ProjectComponentSelector::getProjectPath)
+                                    .collect(Collectors.toSet())));
             task.dependsOn(compileSchemaTask);
         });
     }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/ObjectMappers.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/ObjectMappers.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema.gradle;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.metric.schema.MetricSchema;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.gradle.api.GradleException;
+
+final class ObjectMappers {
+    static final ObjectMapper mapper = com.palantir.conjure.java.serialization.ObjectMappers.newClientObjectMapper();
+
+    static List<MetricSchema> loadMetricSchema(File file) {
+        try {
+            return ObjectMappers.mapper.readValue(file, new TypeReference<List<MetricSchema>>() {});
+        } catch (IOException e) {
+            throw new GradleException("Failed to load metrics from file: " + file, e);
+        }
+    }
+
+    private ObjectMappers() {}
+}


### PR DESCRIPTION
## Before this PR
running `createMetricsManifest` (which was triggered alongside writing locks) would cause all project dependencies to compile

## After this PR
==COMMIT_MSG==
avoid compilation when generating metricsManifest
==COMMIT_MSG==

## Possible downsides?
N/A