### PR TITLE
generateMetricsMarkdown no longer requires `--write-locks`

### DIFF
--- a/changelog/@unreleased/pr-314.v2.yml
+++ b/changelog/@unreleased/pr-314.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: generateMetricsMarkdown no longer requires `--write-locks`
+  links:
+  - https://github.com/palantir/metric-schema/pull/314

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
@@ -17,6 +17,7 @@
 package com.palantir.metric.schema.gradle;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
 import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.markdown.MarkdownRenderer;
 import java.io.File;
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
@@ -32,15 +34,14 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GFileUtils;
 
 @CacheableTask
-public class GenerateMetricMarkdownTask extends DefaultTask {
-    private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
+public class CheckMetricMarkdownTask extends DefaultTask {
+    private final RegularFileProperty markdownFile = getProject().getObjects().fileProperty();
     private final RegularFileProperty manifestFile = getProject().getObjects().fileProperty();
     private final Property<String> localCoordinates = getProject()
             .getObjects()
@@ -59,7 +60,7 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
     public final Provider<RegularFile> getMarkdownFile() {
-        return ProviderUtils.filterNonExistentFile(getProject(), outputFile);
+        return ProviderUtils.filterNonExistentFile(getProject(), markdownFile);
     }
 
     @Input
@@ -67,14 +68,12 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
         return localCoordinates;
     }
 
-    @OutputFile
-    public final RegularFileProperty getOutputFile() {
-        return outputFile;
+    final void setMarkdownFile(File value) {
+        markdownFile.set(value);
     }
 
     @TaskAction
-    public final void generate() throws IOException {
-        File markdown = outputFile.get().getAsFile();
+    public final void check() throws IOException {
         File manifest = getManifestFile().getAsFile().get();
 
         Map<String, List<MetricSchema>> schemas =
@@ -83,7 +82,20 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
             return;
         }
 
+        File markdown = markdownFile.get().getAsFile();
         String upToDateContents = MarkdownRenderer.render(localCoordinates.get(), schemas);
-        GFileUtils.writeFile(upToDateContents, markdown);
+
+        if (!markdown.exists()) {
+            throw new GradleException(String.format(
+                    "%s does not exist, please run `./gradlew %s --write-locks` and commit the resultant file",
+                    markdown.getName(), getName()));
+        } else {
+            String fromDisk = GFileUtils.readFile(markdown);
+            Preconditions.checkState(
+                    fromDisk.equals(upToDateContents),
+                    "%s is out of date, please run `./gradlew %s --write-locks` to update it.",
+                    markdown.getName(),
+                    getName());
+        }
     }
 }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
@@ -87,13 +87,14 @@ public class CheckMetricMarkdownTask extends DefaultTask {
 
         if (!markdown.exists()) {
             throw new GradleException(String.format(
-                    "%s does not exist, please run `./gradlew %s --write-locks` and commit the resultant file",
+                    "%s does not exist, please run `./gradlew %s` or "
+                            + "`./gradlew --write-locks` and commit the resultant file",
                     markdown.getName(), getName()));
         } else {
             String fromDisk = GFileUtils.readFile(markdown);
             Preconditions.checkState(
                     fromDisk.equals(upToDateContents),
-                    "%s is out of date, please run `./gradlew %s --write-locks` to update it.",
+                    "%s is out of date, please run `./gradlew %s` or `./gradlew --write-locks` to update it.",
                     markdown.getName(),
                     getName());
         }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
@@ -34,7 +34,7 @@ public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
         TaskProvider<CreateMetricsManifestTask> createMetricsManifest =
                 project.getTasks().named(MetricSchemaPlugin.CREATE_METRICS_MANIFEST, CreateMetricsManifestTask.class);
 
-        project.getTasks()
+        TaskProvider<GenerateMetricMarkdownTask> generateMetricsMarkdown = project.getTasks()
                 .register(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN, GenerateMetricMarkdownTask.class, task -> {
                     task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
                     task.getOutputFile().set(project.file("metrics.md"));
@@ -46,6 +46,8 @@ public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
                     task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
                     task.setMarkdownFile(project.file("metrics.md"));
                     task.dependsOn(createMetricsManifest);
+                    // Avoid a race when both checkMetricsMarkdown and generateMetricsMarkdown are requested
+                    task.mustRunAfter(generateMetricsMarkdown);
                 });
 
         project.getTasks().named("check", check -> check.dependsOn(checkMetricsMarkdown));

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
@@ -34,20 +34,20 @@ public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
         TaskProvider<CreateMetricsManifestTask> createMetricsManifest =
                 project.getTasks().named(MetricSchemaPlugin.CREATE_METRICS_MANIFEST, CreateMetricsManifestTask.class);
 
-        TaskProvider<GenerateMetricMarkdownTask> generateMetricsMarkdown = project.getTasks()
-                .register(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN, GenerateMetricMarkdownTask.class, task -> {
-                    task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
-                    task.getOutputFile().set(project.file("metrics.md"));
-                    task.dependsOn(createMetricsManifest);
-                });
-
         TaskProvider<CheckMetricMarkdownTask> checkMetricsMarkdown = project.getTasks()
                 .register(MetricSchemaPlugin.CHECK_METRICS_MARKDOWN, CheckMetricMarkdownTask.class, task -> {
                     task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
                     task.setMarkdownFile(project.file("metrics.md"));
                     task.dependsOn(createMetricsManifest);
+                });
+
+        project.getTasks()
+                .register(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN, GenerateMetricMarkdownTask.class, task -> {
+                    task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
+                    task.getOutputFile().set(project.file("metrics.md"));
+                    task.dependsOn(createMetricsManifest);
                     // Avoid a race when both checkMetricsMarkdown and generateMetricsMarkdown are requested
-                    task.mustRunAfter(generateMetricsMarkdown);
+                    task.mustRunAfter(checkMetricsMarkdown);
                 });
 
         project.getTasks().named("check", check -> check.dependsOn(checkMetricsMarkdown));

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
@@ -34,13 +34,21 @@ public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
         TaskProvider<CreateMetricsManifestTask> createMetricsManifest =
                 project.getTasks().named(MetricSchemaPlugin.CREATE_METRICS_MANIFEST, CreateMetricsManifestTask.class);
 
-        TaskProvider<GenerateMetricMarkdownTask> generateMetricsMarkdown = project.getTasks()
+        project.getTasks()
                 .register(MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN, GenerateMetricMarkdownTask.class, task -> {
                     task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
                     task.getOutputFile().set(project.file("metrics.md"));
                     task.dependsOn(createMetricsManifest);
                 });
-        project.getTasks().named("check", check -> check.dependsOn(generateMetricsMarkdown));
+
+        TaskProvider<CheckMetricMarkdownTask> checkMetricsMarkdown = project.getTasks()
+                .register(MetricSchemaPlugin.CHECK_METRICS_MARKDOWN, CheckMetricMarkdownTask.class, task -> {
+                    task.getManifestFile().set(createMetricsManifest.flatMap(CreateMetricsManifestTask::getOutputFile));
+                    task.setMarkdownFile(project.file("metrics.md"));
+                    task.dependsOn(createMetricsManifest);
+                });
+
+        project.getTasks().named("check", check -> check.dependsOn(checkMetricsMarkdown));
 
         // Wire up dependencies so running `./gradlew --write-locks` will update the markdown
         StartParameter startParam = project.getGradle().getStartParameter();

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -37,6 +37,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
     public static final String METRIC_SCHEMA_RESOURCE = "metric-schema/metrics.json";
 
     public static final String COMPILE_METRIC_SCHEMA = "compileMetricSchema";
+    public static final String CHECK_METRICS_MARKDOWN = "checkMetricsMarkdown";
     public static final String GENERATE_METRICS_MARKDOWN = "generateMetricsMarkdown";
     public static final String CREATE_METRICS_MANIFEST = "createMetricsManifest";
 

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
@@ -71,7 +71,7 @@ class GenerateMetricMarkdownIntegrationSpec extends IntegrationSpec {
 
         then:
         def result = runTasksWithFailure(':check')
-        result.wasExecuted(':generateMetricsMarkdown')
+        result.wasExecuted(':checkMetricsMarkdown')
         result.standardError.contains("metrics.md does not exist")
     }
 


### PR DESCRIPTION
The check portion of the task moved to a new `checkMetricsMarkdown`
task.

## Before this PR
Large internal project can update markdown within ten minutes if you get super lucky.

## After this PR
Large internal project can update markdown within a few seconds.

==COMMIT_MSG==
generateMetricsMarkdown no longer requires `--write-locks`
==COMMIT_MSG==

## Possible downsides?
I don't know how to gradle.
![I have no idea what I'm doing](https://i.imgur.com/k0NvESm.png)