### PR TITLE
checkMetricMarkdown failures provide the correct task name

### DIFF
--- a/changelog/@unreleased/pr-324.v2.yml
+++ b/changelog/@unreleased/pr-324.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: checkMetricMarkdown failures provide the correct task name to regenerate
+    markdown
+  links:
+  - https://github.com/palantir/metric-schema/pull/324

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
@@ -96,7 +96,7 @@ public class CheckMetricMarkdownTask extends DefaultTask {
                     fromDisk.equals(upToDateContents),
                     "%s is out of date, please run `./gradlew %s` or `./gradlew --write-locks` to update it.",
                     markdown.getName(),
-                    getName());
+                    MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN);
         }
     }
 }

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
@@ -86,6 +86,7 @@ class GenerateMetricMarkdownIntegrationSpec extends IntegrationSpec {
 
         file('metrics.md') << "foo"
         def result2 = runTasksWithFailure(':check')
-        result2.standardError.contains("metrics.md is out of date")
+        result2.standardError.contains("metrics.md is out of date, please run `./gradlew generateMetricsMarkdown` "
+                + "or `./gradlew --write-locks` to update it.")
     }
 }


### PR DESCRIPTION
`checkMetricMarkdown` does not update the docs, `generateMetricMarkdown` does!

==COMMIT_MSG==
checkMetricMarkdown failures provide the correct task name to regenerate markdown
==COMMIT_MSG==