### PR TITLE
CreateMetricsManifestTask is not cached

### DIFF
--- a/changelog/@unreleased/pr-348.v2.yml
+++ b/changelog/@unreleased/pr-348.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: CreateMetricsManifestTask is not cached and no longer causes confusing
+    errors with false cache hits
+  links:
+  - https://github.com/palantir/metric-schema/pull/348

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
@@ -46,16 +46,12 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
-@CacheableTask
 public class CreateMetricsManifestTask extends DefaultTask {
     private static final Logger log = Logging.getLogger(CreateMetricsManifestTask.class);
 
@@ -66,7 +62,6 @@ public class CreateMetricsManifestTask extends DefaultTask {
 
     @org.gradle.api.tasks.Optional
     @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
     public final RegularFileProperty getMetricsFile() {
         return metricsFile;
     }


### PR DESCRIPTION
We've been unable to write a test to reproduce the failure. It's possible there's an up-to-date failure unrelated to the cache.

## Before this PR
Manifests failed to update in some cases, causing unexpected failures on CI

## After this PR
==COMMIT_MSG==
CreateMetricsManifestTask is not cached and no longer causes confusing errors with false cache hits
==COMMIT_MSG==

## Possible downsides?
caching is great when it works as expected. This task is very fast, so it shouldn't be problematic.