### PR TITLE
Fix generateMetrics build cache behaviour

### DIFF
--- a/changelog/@unreleased/pr-376.v2.yml
+++ b/changelog/@unreleased/pr-376.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: The `generateMetrics` task can now get hits from the gradle build cache
+    irrespective of where the repo is checked out.  Previously you'd only see `FROM-CACHE`
+    hits in the exact checkout path that the original build ran.
+  links:
+  - https://github.com/palantir/metric-schema/pull/376

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
@@ -22,10 +22,15 @@ import com.palantir.metric.schema.JavaGeneratorArgs;
 import java.io.File;
 import java.util.Optional;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GFileUtils;
@@ -39,13 +44,13 @@ public class GenerateMetricSchemaTask extends SourceTask {
         libraryName.set(defaultLibraryName());
     }
 
-    // @Override
-    // @InputFiles
-    // @SkipWhenEmpty
-    // @PathSensitive(PathSensitivity.RELATIVE)
-    // public final FileTree getSource() {
-    //     return super.getSource();
-    // }
+    @Override
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public final FileTree getSource() {
+        return super.getSource();
+    }
 
     @Input
     public final Property<String> getLibraryName() {

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
@@ -39,6 +39,14 @@ public class GenerateMetricSchemaTask extends SourceTask {
         libraryName.set(defaultLibraryName());
     }
 
+    // @Override
+    // @InputFiles
+    // @SkipWhenEmpty
+    // @PathSensitive(PathSensitivity.RELATIVE)
+    // public final FileTree getSource() {
+    //     return super.getSource();
+    // }
+
     @Input
     public final Property<String> getLibraryName() {
         return libraryName;


### PR DESCRIPTION
## Before this PR

I have been looking at a comparative build scan of a local build vs a CI build, and saw this heartbreaking cache miss:

![image](https://user-images.githubusercontent.com/3473798/100291418-9efd1f80-2f75-11eb-9efb-45874f6fbb56.png)

https://gradle.p.b/c/m2khsesqbx2jw/kbk7v6omaei5k/task-inputs?expanded=WyJuejY2Z3RvdTZyNmtjLXNvdXJjZSIsImNwNGxucXJqYXU3d2Etc291cmNlIl0#nz66gtou6r6kc-cacheability

As you can see, we were _so close_ to getting it perfect, but the `/Volumes/git/container-vuln-scanner` path vs `/home/circleci/container-vuln-scanner` thing wrecked us.

_cc @jmcampanini here's another one_

Also jokes that @carterkozak's sixth sense spotted this bug on the original PR: https://github.com/palantir/metric-schema/pull/37#discussion_r354928914

## After this PR
==COMMIT_MSG==
The `generateMetrics` task can now get hits from the gradle build cache irrespective of where the repo is checked out.  Previously you'd only see `FROM-CACHE` hits in the exact checkout path that the original build ran.
==COMMIT_MSG==

I also checked the other tasks annotated with `@CacheableTask`, and none of the others have this problem because they extend DefaultTask so don't have this sneaky implict inherited InputFiles thingy.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->