### PR TITLE
Annotate methods which return values with @CheckReturnValue

### DIFF
--- a/changelog/@unreleased/pr-380.v2.yml
+++ b/changelog/@unreleased/pr-380.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Metric methods which return a value are now annotated with `@CheckReturnValue`
+    to ensure proper usage.
+  links:
+  - https://github.com/palantir/metric-schema/pull/380

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -152,5 +152,6 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
     private static void configureProjectDependencies(Project project) {
         project.getDependencies().add("api", "com.palantir.tritium:tritium-registry");
         project.getDependencies().add("api", "com.palantir.safe-logging:preconditions");
+        project.getDependencies().add("api", "com.google.errorprone:error_prone_annotations");
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -2,6 +2,7 @@ package com.palantir.test;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -49,6 +50,7 @@ public final class MyNamespaceMetrics {
     }
 
     public interface ResponseSizeBuildStage {
+        @CheckReturnValue
         Histogram build();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -27,6 +27,7 @@ public final class MyNamespaceMetrics {
     }
 
     /** A histogram of the number of bytes written into the response. */
+    @CheckReturnValue
     public ResponseSizeBuilderServiceNameStage responseSize() {
         return new ResponseSizeBuilder();
     }
@@ -55,10 +56,12 @@ public final class MyNamespaceMetrics {
     }
 
     public interface ResponseSizeBuilderServiceNameStage {
+        @CheckReturnValue
         ResponseSizeBuilderEndpointStage serviceName(String serviceName);
     }
 
     public interface ResponseSizeBuilderEndpointStage {
+        @CheckReturnValue
         ResponseSizeBuildStage endpoint(String endpoint);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -30,6 +30,7 @@ public final class ReservedConflictMetrics {
     }
 
     /** Uh-oh! */
+    @CheckReturnValue
     public IntBuilderIntStage int_() {
         return new IntBuilder();
     }
@@ -60,6 +61,7 @@ public final class ReservedConflictMetrics {
     }
 
     /** Gauge metric with a single tag. */
+    @CheckReturnValue
     public DoubleBuilderIntStage double_() {
         return new DoubleBuilder();
     }
@@ -75,14 +77,17 @@ public final class ReservedConflictMetrics {
     }
 
     public interface IntBuilderIntStage {
+        @CheckReturnValue
         IntBuilderRegistryStage int_(String int_);
     }
 
     public interface IntBuilderRegistryStage {
+        @CheckReturnValue
         IntBuilderLongStage registry_(String registry_);
     }
 
     public interface IntBuilderLongStage {
+        @CheckReturnValue
         IntBuildStage long_(String long_);
     }
 
@@ -139,6 +144,7 @@ public final class ReservedConflictMetrics {
     }
 
     public interface DoubleBuilderIntStage {
+        @CheckReturnValue
         DoubleBuildStage int_(String int_);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -3,6 +3,7 @@ package com.palantir.test;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -34,6 +35,7 @@ public final class ReservedConflictMetrics {
     }
 
     /** Meter with a single tag. */
+    @CheckReturnValue
     public Meter long_(String int_) {
         return registry.meter(
                 MetricName.builder()
@@ -68,6 +70,7 @@ public final class ReservedConflictMetrics {
     }
 
     public interface IntBuildStage {
+        @CheckReturnValue
         Histogram build();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -2,6 +2,7 @@ package com.palantir.test;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -49,6 +50,7 @@ public final class ServerMetrics {
     }
 
     public interface ResponseSizeBuildStage {
+        @CheckReturnValue
         Histogram build();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -27,6 +27,7 @@ public final class ServerMetrics {
     }
 
     /** A histogram of the number of bytes written into the response. */
+    @CheckReturnValue
     public ResponseSizeBuilderServiceNameStage responseSize() {
         return new ResponseSizeBuilder();
     }
@@ -55,10 +56,12 @@ public final class ServerMetrics {
     }
 
     public interface ResponseSizeBuilderServiceNameStage {
+        @CheckReturnValue
         ResponseSizeBuilderEndpointStage serviceName(String serviceName);
     }
 
     public interface ResponseSizeBuilderEndpointStage {
+        @CheckReturnValue
         ResponseSizeBuildStage endpoint(String endpoint);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -38,6 +38,7 @@ final class VisibilityMetrics {
     }
 
     /** Tagged gauge metric. */
+    @CheckReturnValue
     ComplexBuilderFooStage complex() {
         return new ComplexBuilder();
     }
@@ -54,10 +55,12 @@ final class VisibilityMetrics {
     }
 
     interface ComplexBuilderFooStage {
+        @CheckReturnValue
         ComplexBuilderBarStage foo(String foo);
     }
 
     interface ComplexBuilderBarStage {
+        @CheckReturnValue
         ComplexBuildStage bar(String bar);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -2,6 +2,7 @@ package com.palantir.test;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -26,6 +27,7 @@ final class VisibilityMetrics {
     }
 
     /** just a metric */
+    @CheckReturnValue
     Counter test() {
         return registry.counter(
                 MetricName.builder()

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -217,6 +217,7 @@ final class UtilityGenerator {
                     .addMethod(MethodSpec.methodBuilder(Custodian.sanitizeName(tag))
                             .addParameter(String.class, Custodian.sanitizeName(tag))
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                            .addAnnotation(CheckReturnValue.class)
                             .returns(ClassName.bestGuess(
                                     lastTag ? buildStage(metricName) : stageName(metricName, tagList.get(i + 1))))
                             .build())
@@ -293,6 +294,7 @@ final class UtilityGenerator {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(Custodian.sanitizeName(metricName))
                 .addModifiers(visibility.apply())
                 .returns(ClassName.bestGuess(stageName(metricName, tagList.get(0))))
+                .addAnnotation(CheckReturnValue.class)
                 .addStatement("return new $T()", ClassName.bestGuess(Custodian.anyToUpperCamel(metricName) + "Builder"))
                 .addJavadoc(Javadoc.render(definition.getDocs()));
         outerBuilder.addMethod(methodBuilder.build());

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -18,6 +18,7 @@ package com.palantir.metric.schema;
 
 import com.codahale.metrics.Gauge;
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -166,6 +167,7 @@ final class UtilityGenerator {
                     metricNameMethod.name,
                     ReservedNames.GAUGE_NAME);
         } else {
+            methodBuilder.addAnnotation(CheckReturnValue.class);
             methodBuilder.addStatement(
                     "return $L.$L($L)", ReservedNames.REGISTRY_NAME, metricRegistryMethod, metricNameBlock);
         }
@@ -190,6 +192,8 @@ final class UtilityGenerator {
             abstractBuildMethodBuilder.addParameter(
                     ParameterizedTypeName.get(ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Object.class)),
                     ReservedNames.GAUGE_NAME);
+        } else {
+            abstractBuildMethodBuilder.addAnnotation(CheckReturnValue.class);
         }
         MethodSpec abstractBuildMethod = abstractBuildMethodBuilder.build();
         MethodSpec abstractBuildMetricName = MethodSpec.methodBuilder("buildMetricName")


### PR DESCRIPTION
This ensures that someone doesn't forget to do:

```
metrics.meter("foo")
```

And assume that works, this ensures that they also use the
return value to call `.mark()`.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->