### PR TITLE
improvement: Respect ordering of fields in markdown

### DIFF
--- a/changelog/@unreleased/pr-427.v2.yml
+++ b/changelog/@unreleased/pr-427.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Respect ordering of fields in markdown
+  links:
+  - https://github.com/palantir/metric-schema/pull/427

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.metric.schema.MetricDefinition;
 import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
-import com.palantir.metric.schema.TagDefinition;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -78,14 +77,12 @@ public final class MarkdownRenderer {
         if (!metric.getTags().isEmpty()) {
             output.append(" tagged ")
                     .append(metric.getTags().stream()
-                            .sorted()
                             .map(value -> '`' + value + '`')
                             .collect(Collectors.joining(", ")));
         } else if (!metric.getTagDefinitions().isEmpty()) {
             // TODO(forozco): improve markdown to render tag values and docs
             output.append(" tagged ")
                     .append(metric.getTagDefinitions().stream()
-                            .sorted(Comparator.comparing(TagDefinition::getName))
                             .map(value -> '`' + value.getName() + '`')
                             .collect(Collectors.joining(", ")));
         }

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -182,7 +182,7 @@ class MarkdownRendererTest {
                         + "\n"
                         + "### namespace\n"
                         + "namespace docs\n"
-                        + "- `namespace.metric` tagged `endpoint`, `service` (meter): metric docs");
+                        + "- `namespace.metric` tagged `service`, `endpoint` (meter): metric docs");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Respect ordering of fields in markdown
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->