### PR TITLE
feature: Add support for docs to tag definitions

### DIFF
--- a/changelog/@unreleased/pr-431.v2.yml
+++ b/changelog/@unreleased/pr-431.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add support for docs to tag definitions
+  links:
+  - https://github.com/palantir/metric-schema/pull/431

--- a/metric-schema-api/src/main/conjure/metric-schema-api.yml
+++ b/metric-schema-api/src/main/conjure/metric-schema-api.yml
@@ -38,6 +38,7 @@ types:
       TagDefinition:
         fields:
           name: string
+          docs: optional<Documentation>
           values: set<TagValue>
       TagValue:
         fields:

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -58,6 +58,7 @@ public final class MonitorsMetrics {
     }
 
     public interface ProcessingBuilderResultStage {
+        /** The result of processing */
         @CheckReturnValue
         ProcessingBuilderTypeStage result(Processing_Result result);
     }

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -256,9 +256,11 @@ final class UtilityGenerator {
             boolean lastTag = i == tagList.size() - 1;
             TagDefinition tag = tagList.get(i);
             String tagName = tag.getName();
+            MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(Custodian.sanitizeName(tagName));
+            tag.getDocs().ifPresent(docs -> methodBuilder.addJavadoc(Javadoc.render(docs)));
             outerBuilder.addType(TypeSpec.interfaceBuilder(stageName(metricName, tagName))
                     .addModifiers(visibility.apply())
-                    .addMethod(MethodSpec.methodBuilder(Custodian.sanitizeName(tagName))
+                    .addMethod(methodBuilder
                             .addParameter(getTagClassName(metricName, tag), Custodian.sanitizeName(tagName))
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                             .addAnnotation(CheckReturnValue.class)

--- a/metric-schema-java/src/test/resources/constant-tags.yml
+++ b/metric-schema-java/src/test/resources/constant-tags.yml
@@ -7,5 +7,6 @@ namespaces:
         type: meter
         tags:
           - name: result
+            docs: The result of processing
             values: [success, failure]
           - type

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
@@ -47,6 +47,7 @@ final class LangConverter {
                 .tagDefinitions(definition.tags().stream()
                         .map(tag -> TagDefinition.builder()
                                 .name(tag.name())
+                                .docs(tag.docs().map(Documentation::of))
                                 .values(tag.values().stream()
                                         .map(TagValue::of)
                                         .collect(ImmutableList.toImmutableList()))

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagDefinition.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagDefinition.java
@@ -16,24 +16,33 @@
 
 package com.palantir.metric.schema.lang;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
+@JsonDeserialize(using = TagDefinition.TagDefinitionDeserializer.class)
 public interface TagDefinition {
     String name();
 
+    Optional<String> docs();
+
     List<String> values();
 
-    @JsonCreator
-    static TagDefinition valueOf(String name) {
-        return ImmutableTagDefinition.builder().name(name).build();
-    }
-
-    @JsonCreator
-    static TagDefinition valueOf(@JsonProperty("name") String name, @JsonProperty("values") List<String> values) {
-        return ImmutableTagDefinition.builder().name(name).values(values).build();
+    class TagDefinitionDeserializer extends JsonDeserializer<TagDefinition> {
+        @Override
+        public TagDefinition deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
+            if (parser.currentToken() == JsonToken.VALUE_STRING) {
+                String name = parser.getValueAsString();
+                return ImmutableTagDefinition.builder().name(name).build();
+            }
+            return ImmutableTagDefinition.fromJson(parser.readValueAs(ImmutableTagDefinition.Json.class));
+        }
     }
 }

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -104,6 +104,9 @@ public final class MarkdownRenderer {
                                     .sorted()
                                     .collect(Collectors.joining("`,`", "(`", "`)")));
                 }
+                tagDefinition.getDocs().ifPresent(docs -> {
+                    output.append(": ").append(docs);
+                });
                 output.append("\n");
             });
         }

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -205,6 +205,7 @@ class MarkdownRendererTest {
                                                         .build())
                                                 .tagDefinitions(TagDefinition.builder()
                                                         .name("endpoint")
+                                                        .docs(Documentation.of("Some docs"))
                                                         .build())
                                                 .docs(Documentation.of("metric docs"))
                                                 .build())
@@ -223,7 +224,7 @@ class MarkdownRendererTest {
                         + "namespace docs\n"
                         + "- `namespace.metric` (meter): metric docs\n"
                         + "  - `result` values (`failure`,`success`)\n"
-                        + "  - `endpoint`");
+                        + "  - `endpoint`: Some docs");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Add support for docs to tag definitions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->