### PR TITLE
Fix tag enum names for lower-hyphen inputs

### DIFF
--- a/changelog/@unreleased/pr-434.v2.yml
+++ b/changelog/@unreleased/pr-434.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix tag enum names for lower-hyphen inputs such that UPPER_UNDERSCORE names are used.
+  links:
+  - https://github.com/palantir/metric-schema/pull/434

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/CaseFormats.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/CaseFormats.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.base.CharMatcher;
+import com.palantir.logsafe.Preconditions;
+import java.util.Optional;
+
+/**
+ * Utility functionality for handling guava {@link CaseFormat} values.
+ */
+final class CaseFormats {
+
+    private static final CharMatcher LOWER = CharMatcher.inRange('a', 'z');
+    private static final CharMatcher UPPER = CharMatcher.inRange('A', 'Z');
+    private static final CharMatcher HYPHEN = CharMatcher.is('-');
+    private static final CharMatcher UNDERSCORE = CharMatcher.is('_');
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity") // Easier to follow as a single method
+    static Optional<CaseFormat> estimate(String input) {
+        Preconditions.checkNotNull(input, "Input string is required");
+        int upper = UPPER.countIn(input);
+        int lower = LOWER.countIn(input);
+        int hyphen = HYPHEN.countIn(input);
+        int underscore = UNDERSCORE.countIn(input);
+        // Undefined when no alphabetical characters are found
+        if ((upper == 0 && lower == 0)
+                // Undefined when both hyphens and underscores are present
+                || (hyphen > 0 && underscore > 0)
+                // Upper hyphen isn't real: FOO-BAR
+                || (upper > 0 && hyphen > 0)) {
+            return Optional.empty();
+        }
+        if (lower > 0 && upper > 0) {
+            // Mixed case cannot be combined with underscores or hyphens.
+            if (hyphen != 0 || underscore != 0) {
+                return Optional.empty();
+            }
+            // If the first character isn't [a-zA-Z] we bias toward lower camel to match historical behavior.
+            return Optional.of(UPPER.matches(input.charAt(0)) ? CaseFormat.UPPER_CAMEL : CaseFormat.LOWER_CAMEL);
+        }
+        // match all upper or all lower
+        if (underscore == 0 && hyphen == 0) {
+            return Optional.of(upper > 0 ? CaseFormat.UPPER_UNDERSCORE : CaseFormat.LOWER_UNDERSCORE);
+        }
+
+        if (underscore >= hyphen) {
+            return Optional.of(lower > 0 ? CaseFormat.LOWER_UNDERSCORE : CaseFormat.UPPER_UNDERSCORE);
+        }
+        return Optional.of(CaseFormat.LOWER_HYPHEN);
+    }
+
+    private CaseFormats() {}
+}

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Custodian.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Custodian.java
@@ -19,6 +19,7 @@ package com.palantir.metric.schema;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Splitter;
 import com.palantir.logsafe.Preconditions;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /** Utility functionality to escape metric values for generated java code. */
@@ -42,9 +43,11 @@ final class Custodian {
 
     static String anyToUpperUnderscore(String input) {
         Preconditions.checkNotNull(input, "Input string is required");
-        return String.join(
-                "",
-                CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.UPPER_UNDERSCORE).convertAll(splitter.split(input)));
+        return escapeIfNecessary(splitter.splitToStream(input)
+                .map(segment -> CaseFormats.estimate(segment)
+                        .orElse(CaseFormat.LOWER_CAMEL)
+                        .to(CaseFormat.UPPER_UNDERSCORE, segment))
+                .collect(Collectors.joining("_")));
     }
 
     private static String escapeIfNecessary(String input) {

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/CaseFormatsTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/CaseFormatsTest.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.base.CaseFormat;
+import org.junit.jupiter.api.Test;
+
+class CaseFormatsTest {
+
+    @Test
+    void testLowerCamel() {
+        assertThat(CaseFormats.estimate("fooBar")).hasValue(CaseFormat.LOWER_CAMEL);
+    }
+
+    @Test
+    void testUpperCamel() {
+        assertThat(CaseFormats.estimate("FooBar")).hasValue(CaseFormat.UPPER_CAMEL);
+    }
+
+    @Test
+    void testLowerUnderscore() {
+        assertThat(CaseFormats.estimate("foo_bar")).hasValue(CaseFormat.LOWER_UNDERSCORE);
+    }
+
+    @Test
+    void testUpperUnderscore() {
+        assertThat(CaseFormats.estimate("FOO_BAR")).hasValue(CaseFormat.UPPER_UNDERSCORE);
+    }
+
+    @Test
+    void testLowerHyphen() {
+        assertThat(CaseFormats.estimate("foo-bar")).hasValue(CaseFormat.LOWER_HYPHEN);
+    }
+
+    // edge cases
+
+    @Test
+    void testEmptyString() {
+        assertThat(CaseFormats.estimate("")).isEmpty();
+    }
+
+    @Test
+    void testUpperHyphen() {
+        assertThat(CaseFormats.estimate("FOO-BAR")).isEmpty();
+    }
+
+    @Test
+    void testNumeric5xx() {
+        assertThat(CaseFormats.estimate("5xx")).hasValue(CaseFormat.LOWER_UNDERSCORE);
+    }
+}

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/CustodianTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/CustodianTest.java
@@ -61,4 +61,34 @@ class CustodianTest {
     void testSanitize_leadingNumeric() {
         assertThat(Custodian.sanitizeName("4xx")).isEqualTo("_4xx");
     }
+
+    @Test
+    void testAnyToUpperUnderscore_lowerHyphen() {
+        assertThat(Custodian.anyToUpperUnderscore("foo-bar")).isEqualTo("FOO_BAR");
+    }
+
+    @Test
+    void testAnyToUpperUnderscore_lowerCamel() {
+        assertThat(Custodian.anyToUpperUnderscore("fooBar")).isEqualTo("FOO_BAR");
+    }
+
+    @Test
+    void testAnyToUpperUnderscore_upperCamel() {
+        assertThat(Custodian.anyToUpperUnderscore("FooBar")).isEqualTo("FOO_BAR");
+    }
+
+    @Test
+    void testAnyToUpperUnderscore_upperUnderscore() {
+        assertThat(Custodian.anyToUpperUnderscore("FOO_BAR")).isEqualTo("FOO_BAR");
+    }
+
+    @Test
+    void testAnyToUpperUnderscore_lowerUnderscore() {
+        assertThat(Custodian.anyToUpperUnderscore("foo_bar")).isEqualTo("FOO_BAR");
+    }
+
+    @Test
+    void testAnyToUpperUnderscore_5xx() {
+        assertThat(Custodian.anyToUpperUnderscore("5xx")).isEqualTo("_5XX");
+    }
 }


### PR DESCRIPTION
## Before this PR
Previously the `conjure-undertow` tag resulted in value
`CONJUREUNDERTOW` rather than the expected `CONJURE_UNDERTOW`.

## After this PR
==COMMIT_MSG==
Fix tag enum names for lower-hyphen inputs such that UPPER_UNDERSCORE names are used.
==COMMIT_MSG==

## Possible downsides?
More complex