### PR TITLE
Allow colons in tag values

### DIFF
--- a/changelog/@unreleased/pr-440.v2.yml
+++ b/changelog/@unreleased/pr-440.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow colons in tag constant values
+  links:
+  - https://github.com/palantir/metric-schema/pull/440

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -52,6 +52,20 @@ public final class MonitorsMetrics {
         }
     }
 
+    public enum Processing_Locator {
+        PACKAGE_IDENTIFIER("package:identifier");
+
+        private final String value;
+
+        Processing_Locator(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
     public interface ProcessingBuildStage {
         @CheckReturnValue
         Meter build();
@@ -65,16 +79,24 @@ public final class MonitorsMetrics {
 
     public interface ProcessingBuilderTypeStage {
         @CheckReturnValue
-        ProcessingBuildStage type(String type);
+        ProcessingBuilderLocatorStage type(String type);
+    }
+
+    public interface ProcessingBuilderLocatorStage {
+        @CheckReturnValue
+        ProcessingBuildStage locator(Processing_Locator locator);
     }
 
     private final class ProcessingBuilder
             implements ProcessingBuilderResultStage,
                     ProcessingBuilderTypeStage,
+                    ProcessingBuilderLocatorStage,
                     ProcessingBuildStage {
         private Processing_Result result;
 
         private String type;
+
+        private Processing_Locator locator;
 
         @Override
         public Meter build() {
@@ -83,6 +105,7 @@ public final class MonitorsMetrics {
                             .safeName("monitors.processing")
                             .putSafeTags("result", result.getValue())
                             .putSafeTags("type", type)
+                            .putSafeTags("locator", locator.getValue())
                             .putSafeTags("libraryName", LIBRARY_NAME)
                             .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build());
@@ -99,6 +122,13 @@ public final class MonitorsMetrics {
         public ProcessingBuilder type(String type) {
             Preconditions.checkState(this.type == null, "type is already set");
             this.type = Preconditions.checkNotNull(type, "type is required");
+            return this;
+        }
+
+        @Override
+        public ProcessingBuilder locator(Processing_Locator locator) {
+            Preconditions.checkState(this.locator == null, "locator is already set");
+            this.locator = Preconditions.checkNotNull(locator, "locator is required");
             return this;
         }
     }

--- a/metric-schema-java/src/test/resources/constant-tags.yml
+++ b/metric-schema-java/src/test/resources/constant-tags.yml
@@ -10,3 +10,5 @@ namespaces:
             docs: The result of processing
             values: [success, failure]
           - type
+          - name: locator
+            values: [ package:identifier ]

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
@@ -35,8 +35,10 @@ final class Validator {
     private static final String NAME_SEGMENT_PATTERN = "[a-z0-9][a-zA-Z0-9\\-]*";
     private static final String LAST_NAME_SEGMENT_PATTERN = "[a-zA-Z0-9][a-zA-Z0-9\\-]*";
     private static final String NAME_PATTERN = "(" + NAME_SEGMENT_PATTERN + "\\.)*" + LAST_NAME_SEGMENT_PATTERN;
+    private static final String TAG_VALUE_PATTERN = "[a-zA-Z0-9:.\\-]*";
     private static final Pattern NAME_PREDICATE = Pattern.compile(NAME_PATTERN);
     private static final Pattern SHORT_NAME_PREDICATE = Pattern.compile(SHORT_NAME_PATTERN);
+    private static final Pattern TAG_VALUE_PREDICATE = Pattern.compile(TAG_VALUE_PATTERN);
 
     static void validate(MetricSchema schema) {
         Preconditions.checkNotNull(schema, "MetricSchema is required");
@@ -89,11 +91,11 @@ final class Validator {
                         SafeArg.of("pattern", NAME_PATTERN));
                 tag.getValues().forEach(tagValue -> {
                     Preconditions.checkArgument(
-                            NAME_PREDICATE.matcher(tagValue.getValue()).matches(),
+                            TAG_VALUE_PREDICATE.matcher(tagValue.getValue()).matches(),
                             "tag values must match pattern",
                             SafeArg.of("tag", tag.getName()),
                             SafeArg.of("tagValue", tagValue),
-                            SafeArg.of("pattern", NAME_PATTERN));
+                            SafeArg.of("pattern", TAG_VALUE_PATTERN));
                 });
                 Set<String> uniqueValues =
                         tag.getValues().stream().map(TagValue::getValue).collect(Collectors.toSet());


### PR DESCRIPTION
## Before this PR
Tag constant values can't contain colons, which are useful when referring to maven packages.

## After this PR
==COMMIT_MSG==
Allow colons in tag constant values
==COMMIT_MSG==

Colons are valid in datadog and prometheus.