### PR TITLE
Improvement: Inline single value tags

### DIFF
--- a/changelog/@unreleased/pr-443.v2.yml
+++ b/changelog/@unreleased/pr-443.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Inline single value tags
+  links:
+  - https://github.com/palantir/metric-schema/pull/443

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -52,6 +52,22 @@ public final class MonitorsMetrics {
         }
     }
 
+    public enum Processing_OtherLocator {
+        PACKAGE_IDENTIFIER("package:identifier"),
+
+        PACKAGE_IDENTIFIER2("package:identifier2");
+
+        private final String value;
+
+        Processing_OtherLocator(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
     public interface ProcessingBuildStage {
         @CheckReturnValue
         Meter build();
@@ -65,16 +81,24 @@ public final class MonitorsMetrics {
 
     public interface ProcessingBuilderTypeStage {
         @CheckReturnValue
-        ProcessingBuildStage type(String type);
+        ProcessingBuilderOtherLocatorStage type(String type);
+    }
+
+    public interface ProcessingBuilderOtherLocatorStage {
+        @CheckReturnValue
+        ProcessingBuildStage otherLocator(Processing_OtherLocator otherLocator);
     }
 
     private final class ProcessingBuilder
             implements ProcessingBuilderResultStage,
                     ProcessingBuilderTypeStage,
+                    ProcessingBuilderOtherLocatorStage,
                     ProcessingBuildStage {
         private Processing_Result result;
 
         private String type;
+
+        private Processing_OtherLocator otherLocator;
 
         @Override
         public Meter build() {
@@ -84,6 +108,7 @@ public final class MonitorsMetrics {
                             .putSafeTags("result", result.getValue())
                             .putSafeTags("type", type)
                             .putSafeTags("locator", "package:identifier")
+                            .putSafeTags("otherLocator", otherLocator.getValue())
                             .putSafeTags("libraryName", LIBRARY_NAME)
                             .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build());
@@ -100,6 +125,14 @@ public final class MonitorsMetrics {
         public ProcessingBuilder type(String type) {
             Preconditions.checkState(this.type == null, "type is already set");
             this.type = Preconditions.checkNotNull(type, "type is required");
+            return this;
+        }
+
+        @Override
+        public ProcessingBuilder otherLocator(Processing_OtherLocator otherLocator) {
+            Preconditions.checkState(this.otherLocator == null, "otherLocator is already set");
+            this.otherLocator =
+                    Preconditions.checkNotNull(otherLocator, "otherLocator is required");
             return this;
         }
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -52,20 +52,6 @@ public final class MonitorsMetrics {
         }
     }
 
-    public enum Processing_Locator {
-        PACKAGE_IDENTIFIER("package:identifier");
-
-        private final String value;
-
-        Processing_Locator(String value) {
-            this.value = value;
-        }
-
-        private String getValue() {
-            return value;
-        }
-    }
-
     public interface ProcessingBuildStage {
         @CheckReturnValue
         Meter build();
@@ -79,24 +65,16 @@ public final class MonitorsMetrics {
 
     public interface ProcessingBuilderTypeStage {
         @CheckReturnValue
-        ProcessingBuilderLocatorStage type(String type);
-    }
-
-    public interface ProcessingBuilderLocatorStage {
-        @CheckReturnValue
-        ProcessingBuildStage locator(Processing_Locator locator);
+        ProcessingBuildStage type(String type);
     }
 
     private final class ProcessingBuilder
             implements ProcessingBuilderResultStage,
                     ProcessingBuilderTypeStage,
-                    ProcessingBuilderLocatorStage,
                     ProcessingBuildStage {
         private Processing_Result result;
 
         private String type;
-
-        private Processing_Locator locator;
 
         @Override
         public Meter build() {
@@ -105,7 +83,7 @@ public final class MonitorsMetrics {
                             .safeName("monitors.processing")
                             .putSafeTags("result", result.getValue())
                             .putSafeTags("type", type)
-                            .putSafeTags("locator", locator.getValue())
+                            .putSafeTags("locator", "package:identifier")
                             .putSafeTags("libraryName", LIBRARY_NAME)
                             .putSafeTags("libraryVersion", LIBRARY_VERSION)
                             .build());
@@ -122,13 +100,6 @@ public final class MonitorsMetrics {
         public ProcessingBuilder type(String type) {
             Preconditions.checkState(this.type == null, "type is already set");
             this.type = Preconditions.checkNotNull(type, "type is required");
-            return this;
-        }
-
-        @Override
-        public ProcessingBuilder locator(Processing_Locator locator) {
-            Preconditions.checkState(this.locator == null, "locator is already set");
-            this.locator = Preconditions.checkNotNull(locator, "locator is required");
             return this;
         }
     }

--- a/metric-schema-java/src/test/resources/constant-tags.yml
+++ b/metric-schema-java/src/test/resources/constant-tags.yml
@@ -12,3 +12,5 @@ namespaces:
           - type
           - name: locator
             values: [ package:identifier ]
+          - name: otherLocator
+            values: [ package:identifier, package:identifier2 ]


### PR DESCRIPTION
## Before this PR
Although a tag was declared to have a single value, users were still forced to provide the value when constructing the metric object

## After this PR
==COMMIT_MSG==
Inline single value tags
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->