### PR TITLE
Ignore local metrics in discovered metrics

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
@@ -157,8 +157,11 @@ public class CreateMetricsManifestTask extends DefaultTask {
 
             if (id instanceof ProjectComponentIdentifier) {
                 Project dependencyProject = getProject().project(((ProjectComponentIdentifier) id).getProjectPath());
-                inferProjectDependencyMetrics(dependencyProject)
-                        .ifPresent(metrics -> discoveredMetrics.put(getProjectCoordinates(dependencyProject), metrics));
+                if (!dependencyProject.equals(getProject())) {
+                    inferProjectDependencyMetrics(dependencyProject)
+                            .ifPresent(metrics ->
+                                    discoveredMetrics.put(getProjectCoordinates(dependencyProject), metrics));
+                }
             } else {
                 getExternalMetrics(id, artifact).ifPresent(metrics -> discoveredMetrics.put(id.toString(), metrics));
             }

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -303,4 +303,26 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         manifest['a:a:1.0'] != null
     }
 
+    def 'createManifest ignores local metrics from discovered metrics'() {
+        setup:
+        addSubproject("foo-lib", """
+            dependencies {
+                implementation project(':foo-server')
+            }
+        """)
+
+        addSubproject("foo-server", """
+            dependencies {
+                runtimeOnly project(':foo-lib')
+            }
+        """.stripIndent())
+        def serverMetrics = file('foo-server/src/main/metrics/metric.yml')
+        serverMetrics << METRICS
+
+        when:
+        def result1 = runTasksSuccessfully(':foo-server:createMetricsManifest')
+
+        then:
+        fileExists('foo-server/build/metricSchema/manifest.json')
+    }
 }


### PR DESCRIPTION
We have a project with the following setup:
```gradle
// foo-lib/build.gradle
dependencies {
    implementation project(':foo-server')
}

// foo-server/build.gradle
dependencies {
    runtimeOnly project(':foo-lib')
}
```

`foo-server:createMetricsManifest` fails with `Multiple entries with same key` because the `foo-server` metrics are both local and discovered.

Ideally we would pull out the `foo-server` interfaces needed by `foo-lib` to a separate library, but this is a non-trivial undertaking. It seems reasonable for metric-schema to properly support these types of projects.