### PR TITLE
Add support for unsafe tags

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -153,5 +153,6 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
         project.getDependencies().add("api", "com.palantir.tritium:tritium-registry");
         project.getDependencies().add("api", "com.palantir.safe-logging:preconditions");
         project.getDependencies().add("api", "com.google.errorprone:error_prone_annotations");
+        project.getDependencies().add("implementation", "com.google.guava:guava");
     }
 }

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/GenerateMetricMarkdownIntegrationSpec.groovy
@@ -59,6 +59,7 @@ class GenerateMetricMarkdownIntegrationSpec extends IntegrationSpec {
             resolutionStrategy {
                 force 'com.palantir.tritium:tritium-registry:${Versions.TRITIUM}'
                 force 'com.palantir.safe-logging:preconditions:${Versions.SAFE_LOGGING}'
+                force 'com.google.guava:guava:${Versions.GUAVA}'
             }
         }
         """.stripIndent()

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -69,6 +69,7 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
                 resolutionStrategy {
                     force 'com.palantir.tritium:tritium-registry:${Versions.TRITIUM}'
                     force 'com.palantir.safe-logging:preconditions:${Versions.SAFE_LOGGING}'
+                    force 'com.google.guava:guava:${Versions.GUAVA}'
                 }
             }
         }

--- a/metric-schema-api/src/main/conjure/metric-schema-api.yml
+++ b/metric-schema-api/src/main/conjure/metric-schema-api.yml
@@ -35,9 +35,14 @@ types:
       Documentation:
         docs: Documentation describing an associated component. Markdown syntax may be used.
         alias: string
+      Safety:
+        values:
+          - SAFE
+          - UNSAFE
       TagDefinition:
         fields:
           name: string
+          safety: Safety
           docs: optional<Documentation>
           values: set<TagValue>
       TagValue:

--- a/metric-schema-java/build.gradle
+++ b/metric-schema-java/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // Make sure generated code compiles
     integrationInputImplementation 'com.palantir.tritium:tritium-registry'
     integrationInputImplementation 'com.palantir.safe-logging:preconditions'
+    integrationInputImplementation 'com.google.guava:guava'
     // work around warning about unknown enum constant ImplementationVisibility.PACKAGE
     integrationInputCompileOnly 'org.immutables:value::annotations'
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/SafetyMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/SafetyMetrics.java
@@ -1,0 +1,163 @@
+package com.palantir.test;
+
+import com.codahale.metrics.Counter;
+import com.google.common.hash.Hashing;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Test for tag safety
+ */
+public final class SafetyMetrics {
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION = Optional.ofNullable(
+                    SafetyMetrics.class.getPackage().getImplementationVersion())
+            .orElse("unknown");
+
+    private final TaggedMetricRegistry registry;
+
+    private SafetyMetrics(TaggedMetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    public static SafetyMetrics of(TaggedMetricRegistry registry) {
+        return new SafetyMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
+    }
+
+    /**
+     * A metric with safe and unsafe tags
+     */
+    @CheckReturnValue
+    public TestBuilderSafeStage test() {
+        return new TestBuilder();
+    }
+
+    @Override
+    public String toString() {
+        return "SafetyMetrics{registry=" + registry + '}';
+    }
+
+    public enum Test_SafeMultiple {
+        VALUE1("value1"),
+
+        VALUE2("value2");
+
+        private final String value;
+
+        Test_SafeMultiple(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
+    public enum Test_UnsafeMultiple {
+        VALUE1("value1"),
+
+        VALUE2("value2");
+
+        private final String value;
+
+        Test_UnsafeMultiple(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
+    public interface TestBuildStage {
+        @CheckReturnValue
+        Counter build();
+    }
+
+    public interface TestBuilderSafeStage {
+        @CheckReturnValue
+        TestBuilderUnsafeStage safe(String safe);
+    }
+
+    public interface TestBuilderUnsafeStage {
+        @CheckReturnValue
+        TestBuilderSafeMultipleStage unsafe(String unsafe);
+    }
+
+    public interface TestBuilderSafeMultipleStage {
+        @CheckReturnValue
+        TestBuilderUnsafeMultipleStage safeMultiple(Test_SafeMultiple safeMultiple);
+    }
+
+    public interface TestBuilderUnsafeMultipleStage {
+        @CheckReturnValue
+        TestBuildStage unsafeMultiple(Test_UnsafeMultiple unsafeMultiple);
+    }
+
+    private final class TestBuilder
+            implements TestBuilderSafeStage,
+                    TestBuilderUnsafeStage,
+                    TestBuilderSafeMultipleStage,
+                    TestBuilderUnsafeMultipleStage,
+                    TestBuildStage {
+        private String safe;
+
+        private String unsafe;
+
+        private Test_SafeMultiple safeMultiple;
+
+        private Test_UnsafeMultiple unsafeMultiple;
+
+        @Override
+        public Counter build() {
+            return registry.counter(MetricName.builder()
+                    .safeName("safety.test")
+                    .putSafeTags("safe", safe)
+                    .putSafeTags(
+                            "unsafe",
+                            Hashing.murmur3_32_fixed()
+                                    .hashString(unsafe, StandardCharsets.UTF_8)
+                                    .toString())
+                    .putSafeTags("safe-single", "value")
+                    .putSafeTags("unsafe-single", "value")
+                    .putSafeTags("safe-multiple", safeMultiple.getValue())
+                    .putSafeTags("unsafe-multiple", unsafeMultiple.getValue())
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .build());
+        }
+
+        @Override
+        public TestBuilder safe(String safe) {
+            Preconditions.checkState(this.safe == null, "safe is already set");
+            this.safe = Preconditions.checkNotNull(safe, "safe is required");
+            return this;
+        }
+
+        @Override
+        public TestBuilder unsafe(String unsafe) {
+            Preconditions.checkState(this.unsafe == null, "unsafe is already set");
+            this.unsafe = Preconditions.checkNotNull(unsafe, "unsafe is required");
+            return this;
+        }
+
+        @Override
+        public TestBuilder safeMultiple(Test_SafeMultiple safeMultiple) {
+            Preconditions.checkState(this.safeMultiple == null, "safe-multiple is already set");
+            this.safeMultiple = Preconditions.checkNotNull(safeMultiple, "safe-multiple is required");
+            return this;
+        }
+
+        @Override
+        public TestBuilder unsafeMultiple(Test_UnsafeMultiple unsafeMultiple) {
+            Preconditions.checkState(this.unsafeMultiple == null, "unsafe-multiple is already set");
+            this.unsafeMultiple = Preconditions.checkNotNull(unsafeMultiple, "unsafe-multiple is required");
+            return this;
+        }
+    }
+}

--- a/metric-schema-java/src/test/resources/safety.yml
+++ b/metric-schema-java/src/test/resources/safety.yml
@@ -1,0 +1,24 @@
+namespaces:
+  safety:
+    docs: Test for tag safety
+    metrics:
+      test:
+        type: counter
+        docs: A metric with safe and unsafe tags
+        tags:
+          - name: safe
+            safety: safe
+          - name: unsafe
+            safety: unsafe
+          - name: safe-single
+            safety: safe
+            values: [ value ]
+          - name: unsafe-single
+            safety: unsafe
+            values: [ value ]
+          - name: safe-multiple
+            safety: safe
+            values: [ value1, value2 ]
+          - name: unsafe-multiple
+            safety: unsafe
+            values: [ value1, value2 ]

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
@@ -22,6 +22,7 @@ import com.palantir.metric.schema.Documentation;
 import com.palantir.metric.schema.MetricDefinition;
 import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
+import com.palantir.metric.schema.Safety;
 import com.palantir.metric.schema.TagDefinition;
 import com.palantir.metric.schema.TagValue;
 
@@ -47,6 +48,7 @@ final class LangConverter {
                 .tagDefinitions(definition.tags().stream()
                         .map(tag -> TagDefinition.builder()
                                 .name(tag.name())
+                                .safety(convert(tag.safety()))
                                 .docs(tag.docs().map(Documentation::of))
                                 .values(tag.values().stream()
                                         .map(TagValue::of)
@@ -55,6 +57,14 @@ final class LangConverter {
                         .collect(ImmutableList.toImmutableList()))
                 .docs(Documentation.of(definition.docs()))
                 .build();
+    }
+
+    private static Safety convert(LangSafety safety) {
+        if (safety.equals(LangSafety.SAFE)) {
+            return Safety.SAFE;
+        } else {
+            return Safety.UNSAFE;
+        }
     }
 
     private LangConverter() {}

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangSafety.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangSafety.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.palantir.metric.schema.gradle
+package com.palantir.metric.schema.lang;
 
-class Versions {
-    public static final String TRITIUM = "0.16.3"
-    public static final String SAFE_LOGGING = "1.11.0"
-    public static final String GUAVA = "31.0-jre"
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-    private Versions() { }
+public enum LangSafety {
+    @JsonProperty("safe")
+    SAFE,
+    @JsonProperty("unsafe")
+    UNSAFE;
 }

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagDefinition.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagDefinition.java
@@ -24,12 +24,18 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
 @JsonDeserialize(using = TagDefinition.TagDefinitionDeserializer.class)
 public interface TagDefinition {
     String name();
+
+    @Default
+    default LangSafety safety() {
+        return LangSafety.SAFE;
+    }
 
     Optional<String> docs();
 

--- a/metric-schema-lang/src/test/java/com/palantir/metric/schema/lang/ValidatorTest.java
+++ b/metric-schema-lang/src/test/java/com/palantir/metric/schema/lang/ValidatorTest.java
@@ -25,6 +25,7 @@ import com.palantir.metric.schema.MetricDefinition;
 import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.MetricType;
+import com.palantir.metric.schema.Safety;
 import com.palantir.metric.schema.TagDefinition;
 import org.junit.jupiter.api.Test;
 
@@ -121,6 +122,7 @@ class ValidatorTest {
                                                         .type(MetricType.COUNTER)
                                                         .tagDefinitions(TagDefinition.builder()
                                                                 .name("")
+                                                                .safety(Safety.SAFE)
                                                                 .build())
                                                         .build())
                                         .build())

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -25,6 +25,7 @@ import com.palantir.metric.schema.MetricDefinition;
 import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.MetricType;
+import com.palantir.metric.schema.Safety;
 import com.palantir.metric.schema.TagDefinition;
 import com.palantir.metric.schema.TagValue;
 import org.junit.jupiter.api.Test;
@@ -200,11 +201,13 @@ class MarkdownRendererTest {
                                                 .type(MetricType.METER)
                                                 .tagDefinitions(TagDefinition.builder()
                                                         .name("result")
+                                                        .safety(Safety.SAFE)
                                                         .values(TagValue.of("success"))
                                                         .values(TagValue.of("failure"))
                                                         .build())
                                                 .tagDefinitions(TagDefinition.builder()
                                                         .name("endpoint")
+                                                        .safety(Safety.SAFE)
                                                         .docs(Documentation.of("Some docs"))
                                                         .build())
                                                 .docs(Documentation.of("metric docs"))


### PR DESCRIPTION
## Before this PR
All tags values are assumed to be safe.

## After this PR
Tag values are safe by default but may be declared as unsafe. Unsafe tags that allow arbitrary values will have their values hashed with Murmur3 when building the metric name.

## Questions
- Does this approach look correct? Are there any concerns with this feature?
- Would it be preferable to push the concept of safety into `MetricName`?
- Is Murmur3 an appropriate hash function?