### PR TITLE
Keep sourceDirs and generatedSourceDirs mutable by adding to existing…

### DIFF
--- a/changelog/@unreleased/pr-625.v2.yml
+++ b/changelog/@unreleased/pr-625.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: Instead of setting sourceDirs and generatedSourceDirs to be an ImmutableSet,
+    retrieve the existing respective sets and add to them. This is the commonly accepted
+    method of appending sourceDirs and generatedSourceDirs, and keeps each set mutable
+    to avoid breaking other plugins.
+  links:
+  - https://github.com/palantir/metric-schema/pull/625

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -16,8 +16,6 @@
 
 package com.palantir.metric.schema.gradle;
 
-import com.google.common.collect.ImmutableSet;
-import java.io.File;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -137,14 +135,8 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
             project.getTasks().getByName("ideaModule", task -> task.dependsOn(generateMetrics));
             project.getExtensions().configure(IdeaModel.class, idea -> {
                 IdeaModule module = idea.getModule();
-                module.setSourceDirs(ImmutableSet.<File>builder()
-                        .addAll(module.getSourceDirs())
-                        .add(outputDir.get().getAsFile())
-                        .build());
-                module.setGeneratedSourceDirs(ImmutableSet.<File>builder()
-                        .addAll(module.getGeneratedSourceDirs())
-                        .add(outputDir.get().getAsFile())
-                        .build());
+                module.getSourceDirs().add(outputDir.get().getAsFile());
+                module.getGeneratedSourceDirs().add(outputDir.get().getAsFile());
             });
         });
     }


### PR DESCRIPTION
Pulling over from https://github.com/palantir/metric-schema/pull/517 onto in-repo branch

## Before this PR
The current implementation of the MetricSchemaPlugin sets sourceDirs and generatedSourceDirs to be immutable sets. However, other gradle plugins do not expect these sets to be immutable. Making them immutable can break other plugins that add to sourceDirs or generatedSourceDirs in a mutable fashion.

## After this PR
==COMMIT_MSG==
Keep sourceDirs and generatedSourceDirs mutable by adding to existing set.

Instead of setting sourceDirs and generatedSourceDirs to be an ImmutableSet, retrieve the existing respective sets and add to them. This is the commonly accepted method of appending sourceDirs and generatedSourceDirs, and keeps each set mutable to avoid breaking other plugins. 
==COMMIT_MSG==

## Possible downsides?
The MetricsSchemaPlugin now depends on other plugins maintaining the mutability of sourceDirs and generatedSourceDirs. 