### PR TITLE
Add JSR330's Inject annotation when available

### DIFF
--- a/changelog/@unreleased/pr-778.v2.yml
+++ b/changelog/@unreleased/pr-778.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add dagger's Inject and Reusable annotations when available on the
+    classpath
+  links:
+  - https://github.com/palantir/metric-schema/pull/778

--- a/changelog/@unreleased/pr-778.v2.yml
+++ b/changelog/@unreleased/pr-778.v2.yml
@@ -1,6 +1,5 @@
 type: improvement
 improvement:
-  description: Add dagger's Inject and Reusable annotations when available on the
-    classpath
+  description: Add JSR-330's Inject annotation when jakarta.inject is on the classpath
   links:
   - https://github.com/palantir/metric-schema/pull/778

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
@@ -37,6 +37,8 @@ import org.gradle.util.GFileUtils;
 public abstract class GenerateMetricSchemaTask extends DefaultTask {
     private final Property<String> libraryName =
             getProject().getObjects().property(String.class).value(defaultLibraryName());
+    private final Property<Boolean> generateDaggerAnnotations =
+            getProject().getObjects().property(Boolean.class).value(false);
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -45,6 +47,11 @@ public abstract class GenerateMetricSchemaTask extends DefaultTask {
     @Input
     public final Property<String> getLibraryName() {
         return libraryName;
+    }
+
+    @Input
+    public final Property<Boolean> getGenerateDaggerAnnotations() {
+        return generateDaggerAnnotations;
     }
 
     @OutputDirectory
@@ -60,6 +67,7 @@ public abstract class GenerateMetricSchemaTask extends DefaultTask {
                 .input(getInputFile().getAsFile().get().toPath())
                 .output(output.toPath())
                 .libraryName(Optional.ofNullable(libraryName.getOrNull()))
+                .generateDaggerAnnotations(getGenerateDaggerAnnotations().get())
                 // TODO(forozco): probably want something better
                 .defaultPackageName(getProject().getGroup().toString())
                 .build());

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricSchemaTask.java
@@ -50,7 +50,7 @@ public abstract class GenerateMetricSchemaTask extends DefaultTask {
     }
 
     @Input
-    public final Property<Boolean> getGenerateDaggerAnnotations() {
+    public final Property<Boolean> getGenerateInjectAnnotation() {
         return generateDaggerAnnotations;
     }
 
@@ -67,7 +67,7 @@ public abstract class GenerateMetricSchemaTask extends DefaultTask {
                 .input(getInputFile().getAsFile().get().toPath())
                 .output(output.toPath())
                 .libraryName(Optional.ofNullable(libraryName.getOrNull()))
-                .generateDaggerAnnotations(getGenerateDaggerAnnotations().get())
+                .generateInjectAnnotation(getGenerateInjectAnnotation().get())
                 // TODO(forozco): probably want something better
                 .defaultPackageName(getProject().getGroup().toString())
                 .build());

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -59,7 +59,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                     task.setDescription("Generates bindings for producing well defined metrics");
                     task.getInputFile().set(compileSchemaTask.flatMap(CompileMetricSchemaTask::getOutputFile));
                     task.getOutputDir().set(generatedJavaOutputDir);
-                    task.getGenerateDaggerAnnotations().set(project.provider(() -> hasDaggerOnClasspath(project)));
+                    task.getGenerateInjectAnnotation().set(project.provider(() -> hasInjectionFramework(project)));
                 });
         project.getTasks().named("compileJava", compileJava -> compileJava.dependsOn(generateMetricsTask));
 
@@ -74,15 +74,15 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                         .apply(MetricSchemaMarkdownPlugin.class));
     }
 
-    private static boolean hasDaggerOnClasspath(Project project) {
+    private static boolean hasInjectionFramework(Project project) {
         Configuration compileClasspath = project.getConfigurations().getByName("compileClasspath");
         return compileClasspath.getResolvedConfiguration().getResolvedArtifacts().stream()
                 .map(ResolvedArtifact::getId)
                 .map(ComponentArtifactIdentifier::getComponentIdentifier)
                 .filter(ModuleComponentIdentifier.class::isInstance)
                 .map(ModuleComponentIdentifier.class::cast)
-                .anyMatch(id -> id.getGroup().equals("com.google.dagger")
-                        && id.getModule().equals("dagger"));
+                .anyMatch(id ->
+                        id.getGroup().equals("jakarta.inject") && id.getModule().equals("jakarta.inject-api"));
     }
 
     private static void createManifestTask(

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -100,24 +100,23 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         new File(projectDir, path).readLines().any { line -> (line == text) }
     }
 
-    def 'generates java without dagger support'() {
+    def 'generates java without Inject support'() {
         when:
         file('src/main/metrics/metrics.yml') << METRICS
 
         then:
         def result = runTasksSuccessfully('classes')
         result.wasExecuted(':generateMetrics')
-        !fileContainsLine(OUTPUT_JAVA_FILE, "import dagger.Reusable;")
         !fileContainsLine(OUTPUT_JAVA_FILE, "import javax.inject.Inject;")
     }
 
-    def 'generates java with dagger support'() {
+    def 'generates java with Inject support'() {
         when:
         file('src/main/metrics/metrics.yml') << METRICS
         buildFile.append("""
         allprojects {
             dependencies {
-                api 'com.google.dagger:dagger:2.41'
+                api 'jakarta.inject:jakarta.inject-api:1.0'
             }
         }
         """.stripIndent())
@@ -125,7 +124,6 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         then:
         def result = runTasksSuccessfully('classes')
         result.wasExecuted(':generateMetrics')
-        fileContainsLine(OUTPUT_JAVA_FILE, "import dagger.Reusable;")
         fileContainsLine(OUTPUT_JAVA_FILE, "import javax.inject.Inject;")
     }
 

--- a/metric-schema-java/build.gradle
+++ b/metric-schema-java/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 sourceSets {
     integrationInput
+    integrationInputWithDagger
 }
 
 idea {
@@ -12,6 +13,13 @@ idea {
 }
 
 tasks.checkstyleIntegrationInput.enabled = false
+
+// Setup integrationInputWithDagger to inherit integrationInput's dependencies
+["Implementation", "CompileOnly"].forEach { subCfg ->
+    configurations.named("integrationInputWithDagger" + subCfg).configure {
+        extendsFrom configurations.getByName("integrationInput" + subCfg)
+    }
+}
 
 dependencies {
     implementation project(':metric-schema-api:metric-schema-api-objects')
@@ -40,10 +48,12 @@ dependencies {
     integrationInputImplementation 'com.palantir.safe-logging:preconditions'
     // work around warning about unknown enum constant ImplementationVisibility.PACKAGE
     integrationInputCompileOnly 'org.immutables:value::annotations'
+
+    integrationInputWithDaggerImplementation 'com.google.dagger:dagger'
 }
 
 // Ignore generated code when formatting since we currently use g-j-f in code and p-j-f in gradle
 spotless.java {
-    targetExclude = sourceSets.integrationInput.java
+    targetExclude = sourceSets.integrationInput.java + sourceSets.integrationInputWithDagger.java
     target target
 }

--- a/metric-schema-java/build.gradle
+++ b/metric-schema-java/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 sourceSets {
     integrationInput
-    integrationInputWithDagger
+    integrationInputWithInject
 }
 
 idea {
@@ -13,11 +13,11 @@ idea {
 }
 
 tasks.checkstyleIntegrationInput.enabled = false
-tasks.checkstyleIntegrationInputWithDagger.enabled = false
+tasks.checkstyleIntegrationInputWithInject.enabled = false
 
-// Setup integrationInputWithDagger to inherit integrationInput's dependencies
+// Setup integrationInputWithInject to inherit integrationInput's dependencies
 ["Implementation", "CompileOnly"].forEach { subCfg ->
-    configurations.named("integrationInputWithDagger" + subCfg).configure {
+    configurations.named("integrationInputWithInject" + subCfg).configure {
         extendsFrom configurations.getByName("integrationInput" + subCfg)
     }
 }
@@ -50,11 +50,11 @@ dependencies {
     // work around warning about unknown enum constant ImplementationVisibility.PACKAGE
     integrationInputCompileOnly 'org.immutables:value::annotations'
 
-    integrationInputWithDaggerImplementation 'com.google.dagger:dagger'
+    integrationInputWithInjectImplementation 'jakarta.inject:jakarta.inject-api'
 }
 
 // Ignore generated code when formatting since we currently use g-j-f in code and p-j-f in gradle
 spotless.java {
-    targetExclude = sourceSets.integrationInput.java + sourceSets.integrationInputWithDagger.java
+    targetExclude = sourceSets.integrationInput.java + sourceSets.integrationInputWithInject.java
     target target
 }

--- a/metric-schema-java/build.gradle
+++ b/metric-schema-java/build.gradle
@@ -13,6 +13,7 @@ idea {
 }
 
 tasks.checkstyleIntegrationInput.enabled = false
+tasks.checkstyleIntegrationInputWithDagger.enabled = false
 
 // Setup integrationInputWithDagger to inherit integrationInput's dependencies
 ["Implementation", "CompileOnly"].forEach { subCfg ->

--- a/metric-schema-java/src/integrationInputWithDagger/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInputWithDagger/java/com/palantir/test/ServerMetrics.java
@@ -1,0 +1,109 @@
+package com.palantir.test;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import dagger.Reusable;
+import java.util.Objects;
+import javax.inject.Inject;
+
+/**
+ * General web server metrics.
+ */
+@Reusable
+public final class ServerMetrics {
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION =
+            Objects.requireNonNullElse(ServerMetrics.class.getPackage().getImplementationVersion(), "unknown");
+
+    private final TaggedMetricRegistry registry;
+
+    @Inject
+    public ServerMetrics(TaggedMetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    public static ServerMetrics of(TaggedMetricRegistry registry) {
+        return new ServerMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
+    }
+
+    /**
+     * A histogram of the number of bytes written into the response.
+     */
+    @CheckReturnValue
+    public ResponseSizeBuilderServiceNameStage responseSize() {
+        return new ResponseSizeBuilder();
+    }
+
+    /**
+     * A gauge of the ratio of active workers to the number of workers.
+     */
+    public void workerUtilization(Gauge<?> gauge) {
+        registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
+    }
+
+    public static MetricName workerUtilizationMetricName() {
+        return MetricName.builder()
+                .safeName("server.worker.utilization")
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "ServerMetrics{registry=" + registry + '}';
+    }
+
+    public interface ResponseSizeBuildStage {
+        @CheckReturnValue
+        Histogram build();
+    }
+
+    public interface ResponseSizeBuilderServiceNameStage {
+        @CheckReturnValue
+        ResponseSizeBuilderEndpointStage serviceName(@Safe String serviceName);
+    }
+
+    public interface ResponseSizeBuilderEndpointStage {
+        @CheckReturnValue
+        ResponseSizeBuildStage endpoint(@Safe String endpoint);
+    }
+
+    private final class ResponseSizeBuilder
+            implements ResponseSizeBuilderServiceNameStage, ResponseSizeBuilderEndpointStage, ResponseSizeBuildStage {
+        private String serviceName;
+
+        private String endpoint;
+
+        @Override
+        public Histogram build() {
+            return registry.histogram(MetricName.builder()
+                    .safeName("server.response.size")
+                    .putSafeTags("service-name", serviceName)
+                    .putSafeTags("endpoint", endpoint)
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .build());
+        }
+
+        @Override
+        public ResponseSizeBuilder serviceName(@Safe String serviceName) {
+            Preconditions.checkState(this.serviceName == null, "service-name is already set");
+            this.serviceName = Preconditions.checkNotNull(serviceName, "service-name is required");
+            return this;
+        }
+
+        @Override
+        public ResponseSizeBuilder endpoint(@Safe String endpoint) {
+            Preconditions.checkState(this.endpoint == null, "endpoint is already set");
+            this.endpoint = Preconditions.checkNotNull(endpoint, "endpoint is required");
+            return this;
+        }
+    }
+}

--- a/metric-schema-java/src/integrationInputWithInject/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInputWithInject/java/com/palantir/test/ServerMetrics.java
@@ -7,14 +7,12 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import dagger.Reusable;
 import java.util.Objects;
 import javax.inject.Inject;
 
 /**
  * General web server metrics.
  */
-@Reusable
 public final class ServerMetrics {
     private static final String LIBRARY_NAME = "witchcraft";
 

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
@@ -45,7 +45,7 @@ public final class JavaGenerator {
                             args.libraryName(),
                             getPackage(args, schema),
                             getVisibility(schema),
-                            args.getGenerateDaggerAnnotations());
+                            args.getGenerateInjectAnnotation());
                 }))
                 .map(javaFile -> Goethe.formatAndEmit(javaFile, args.output()))
                 .collect(ImmutableList.toImmutableList());

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
@@ -44,7 +44,8 @@ public final class JavaGenerator {
                             entry.getValue(),
                             args.libraryName(),
                             getPackage(args, schema),
-                            getVisibility(schema));
+                            getVisibility(schema),
+                            args.getGenerateDaggerAnnotations());
                 }))
                 .map(javaFile -> Goethe.formatAndEmit(javaFile, args.output()))
                 .collect(ImmutableList.toImmutableList());

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGeneratorArgs.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGeneratorArgs.java
@@ -51,6 +51,12 @@ public abstract class JavaGeneratorArgs {
     /** The default Java package name for generated classes. */
     abstract String defaultPackageName();
 
+    /** Should Dagger's @Inject and @Reusable annotations be added to generated types. */
+    @Value.Default
+    boolean getGenerateDaggerAnnotations() {
+        return false;
+    }
+
     @Value.Check
     final void check() {
         libraryName().ifPresent(value -> {

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGeneratorArgs.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGeneratorArgs.java
@@ -51,9 +51,9 @@ public abstract class JavaGeneratorArgs {
     /** The default Java package name for generated classes. */
     abstract String defaultPackageName();
 
-    /** Should Dagger's @Inject and @Reusable annotations be added to generated types. */
+    /** Should the JSR-330 @Inject annotation be added to generated types. */
     @Value.Default
-    boolean getGenerateDaggerAnnotations() {
+    boolean getGenerateInjectAnnotation() {
         return false;
     }
 

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -46,7 +46,7 @@ final class UtilityGenerator {
             Optional<String> libraryName,
             String packageName,
             ImplementationVisibility visibility,
-            boolean generateDaggerAnnotations) {
+            boolean generateInjectAnnotation) {
         ClassName className =
                 ClassName.get(packageName, className(metrics.getShortName().orElse(namespace)));
         TypeSpec.Builder builder = TypeSpec.classBuilder(className.simpleName())
@@ -84,9 +84,8 @@ final class UtilityGenerator {
                 .addParameter(TaggedMetricRegistry.class, ReservedNames.REGISTRY_NAME)
                 .addStatement("this.$1L = $1L", ReservedNames.REGISTRY_NAME);
 
-        if (generateDaggerAnnotations) {
+        if (generateInjectAnnotation) {
             ctorBuilder.addModifiers(Modifier.PUBLIC).addAnnotation(ClassName.get("javax.inject", "Inject"));
-            builder.addAnnotation(ClassName.get("dagger", "Reusable"));
         } else {
             ctorBuilder.addModifiers(Modifier.PRIVATE);
         }

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/JavaGeneratorTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/JavaGeneratorTest.java
@@ -41,7 +41,7 @@ public class JavaGeneratorTest {
 
     private static final String REFERENCE_FILES_FOLDER = "src/integrationInput/java";
 
-    private static final String DAGGER_REFERENCE_FILES_FOLDER = "src/integrationInputWithDagger/java";
+    private static final String INJECT_REFERENCE_FILES_FOLDER = "src/integrationInputWithInject/java";
 
     @TempDir
     public Path outputDir;
@@ -50,7 +50,7 @@ public class JavaGeneratorTest {
     public Path inputDir;
 
     @Test
-    void generates_code_without_dagger() {
+    void generates_code_without_inject() {
         JavaGenerator.generate(JavaGeneratorArgs.builder()
                         .output(outputDir)
                         .input(compileAndEmit(listFiles(Paths.get("src/test/resources"), _path -> true)))
@@ -65,20 +65,20 @@ public class JavaGeneratorTest {
     }
 
     @Test
-    void generates_code_with_dagger() {
+    void generates_code_with_inject() {
         JavaGenerator.generate(JavaGeneratorArgs.builder()
                         .output(outputDir)
                         .input(compileAndEmit(listFiles(Paths.get("src/test/resources"), path -> path.getFileName()
                                 .startsWith("server.yml"))))
                         .defaultPackageName("com.palantir.test")
                         .libraryName("witchcraft")
-                        .generateDaggerAnnotations(true)
+                        .generateInjectAnnotation(true)
                         .build())
                 .stream()
                 .map(outputDir::relativize)
                 .map(Path::toString)
                 .forEach(relativePath ->
-                        assertThatFilesAreTheSame(outputDir.resolve(relativePath), DAGGER_REFERENCE_FILES_FOLDER));
+                        assertThatFilesAreTheSame(outputDir.resolve(relativePath), INJECT_REFERENCE_FILES_FOLDER));
     }
 
     private void assertThatFilesAreTheSame(Path outputFile, String referenceFilesFolder) {

--- a/versions.props
+++ b/versions.props
@@ -20,6 +20,9 @@ com.palantir.safe-logging:preconditions = 1.11.0
 com.palantir.goethe:* = 0.7.0
 commons-io:commons-io = 2.11.0
 
+# just for verifying generated dagger annotations compile
+com.google.dagger:* = 2.41
+
 # conflict resolution
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:error_prone_annotations = 2.11.0

--- a/versions.props
+++ b/versions.props
@@ -20,8 +20,8 @@ com.palantir.safe-logging:preconditions = 1.11.0
 com.palantir.goethe:* = 0.7.0
 commons-io:commons-io = 2.11.0
 
-# just for verifying generated dagger annotations compile
-com.google.dagger:* = 2.41
+# just for verifying generated Inject annotations compile
+jakarta.inject:jakarta.inject-api = 1.0
 
 # conflict resolution
 com.google.code.findbugs:jsr305 = 3.0.2


### PR DESCRIPTION
## Before this PR
Consumers of metric-schema that use dagger end up manually creating modules that @Provide every generated metric schema type.

## After this PR
==COMMIT_MSG==
Add JSR330's Inject annotation when available
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->