### PR TITLE
Allow empty schemas in check markdown task

### DIFF
--- a/changelog/@unreleased/pr-802.v2.yml
+++ b/changelog/@unreleased/pr-802.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow empty schemas in check markdown task
+  links:
+  - https://github.com/palantir/metric-schema/pull/802

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
@@ -78,7 +78,7 @@ public class CheckMetricMarkdownTask extends DefaultTask {
 
         Map<String, List<MetricSchema>> schemas =
                 ObjectMappers.mapper.readValue(manifest, new TypeReference<Map<String, List<MetricSchema>>>() {});
-        if (schemas.isEmpty()) {
+        if (isEmpty(schemas)) {
             return;
         }
 
@@ -98,5 +98,9 @@ public class CheckMetricMarkdownTask extends DefaultTask {
                     markdown.getName(),
                     MetricSchemaPlugin.GENERATE_METRICS_MARKDOWN);
         }
+    }
+
+    private static boolean isEmpty(Map<String, List<MetricSchema>> schemas) {
+        return schemas.isEmpty() || schemas.values().stream().allMatch(List::isEmpty);
     }
 }


### PR DESCRIPTION
## Before this PR
Expands the definition of "empty" schema to support the following, by copying the logic that already exists in the generate task.

```
{"$project:$projectVersion":[]}
```
## After this PR
==COMMIT_MSG==
Allow empty schemas in check markdown task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->