### PR TITLE
gradle task configuration avoidance

### DIFF
--- a/changelog/@unreleased/pr-805.v2.yml
+++ b/changelog/@unreleased/pr-805.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid creating and configuring gradle tasks
+  links:
+  - https://github.com/palantir/metric-schema/pull/805

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaMarkdownPlugin.java
@@ -50,7 +50,7 @@ public final class MetricSchemaMarkdownPlugin implements Plugin<Project> {
                     task.mustRunAfter(checkMetricsMarkdown);
                 });
 
-        project.getTasks().named("check", check -> check.dependsOn(checkMetricsMarkdown));
+        project.getTasks().named("check").configure(check -> check.dependsOn(checkMetricsMarkdown));
 
         // Wire up dependencies so running `./gradlew --write-locks` will update the markdown
         StartParameter startParam = project.getGradle().getStartParameter();


### PR DESCRIPTION
## Before this PR
We are unnecessarily creating and configuring tasks during gradle configuration. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more details.

## After this PR
==COMMIT_MSG==
Avoid creating and configuring gradle tasks
==COMMIT_MSG==

## Possible downsides?
None.