### PR TITLE
metric-schema includes the java version by default as a `javaVersion` tag

### DIFF
--- a/changelog/@unreleased/pr-832.v2.yml
+++ b/changelog/@unreleased/pr-832.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: metric-schema includes the java version by default as a `javaVersion`
-    tag, for example
+    tag, for example `javaVersion:17.0.3`
   links:
   - https://github.com/palantir/metric-schema/pull/832

--- a/changelog/@unreleased/pr-832.v2.yml
+++ b/changelog/@unreleased/pr-832.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: metric-schema includes the java version by default as a `javaVersion`
+    tag, for example
+  links:
+  - https://github.com/palantir/metric-schema/pull/832

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -12,6 +12,8 @@ import java.util.Objects;
  * General web server metrics.
  */
 public final class MonitorsMetrics {
+    private static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+
     private static final String LIBRARY_NAME = "witchcraft";
 
     private static final String LIBRARY_VERSION =
@@ -46,6 +48,7 @@ public final class MonitorsMetrics {
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
                 .build());
     }
 
@@ -130,6 +133,7 @@ public final class MonitorsMetrics {
                     .putSafeTags("otherLocator", otherLocator.getValue())
                     .putSafeTags("libraryName", LIBRARY_NAME)
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
                     .build());
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -13,6 +13,8 @@ import java.util.Objects;
  * General web server metrics.
  */
 public final class MyNamespaceMetrics {
+    private static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+
     private static final String LIBRARY_NAME = "witchcraft";
 
     private static final String LIBRARY_VERSION =
@@ -48,6 +50,7 @@ public final class MyNamespaceMetrics {
                 .safeName("com.palantir.very.long.namespace.worker.utilization")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
                 .build();
     }
 
@@ -85,6 +88,7 @@ public final class MyNamespaceMetrics {
                     .putSafeTags("endpoint", endpoint)
                     .putSafeTags("libraryName", LIBRARY_NAME)
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
                     .build());
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -14,6 +14,8 @@ import java.util.Objects;
  * Tests that reserved words are escaped.
  */
 public final class ReservedConflictMetrics {
+    private static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+
     private static final String LIBRARY_NAME = "witchcraft";
 
     private static final String LIBRARY_VERSION = Objects.requireNonNullElse(
@@ -47,6 +49,7 @@ public final class ReservedConflictMetrics {
                 .putSafeTags("int", int_)
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
                 .build());
     }
 
@@ -62,6 +65,7 @@ public final class ReservedConflictMetrics {
                 .safeName("reserved.conflict.float")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
                 .build();
     }
 
@@ -115,6 +119,7 @@ public final class ReservedConflictMetrics {
                     .putSafeTags("long", long_)
                     .putSafeTags("libraryName", LIBRARY_NAME)
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
                     .build());
         }
 
@@ -166,6 +171,7 @@ public final class ReservedConflictMetrics {
                     .putSafeTags("int", int_)
                     .putSafeTags("libraryName", LIBRARY_NAME)
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
                     .build();
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -77,6 +77,22 @@ public final class ReservedConflictMetrics {
         return new DoubleBuilder();
     }
 
+    /**
+     * docs.
+     */
+    @CheckReturnValue
+    public IncludesDefaultTagsBuilderJavaVersionStage includesDefaultTags() {
+        return new IncludesDefaultTagsBuilder();
+    }
+
+    /**
+     * docs.
+     */
+    @CheckReturnValue
+    public IncludesDefaultTagsDifferentCaseBuilderJavaversionStage includesDefaultTagsDifferentCase() {
+        return new IncludesDefaultTagsDifferentCaseBuilder();
+    }
+
     @Override
     public String toString() {
         return "ReservedConflictMetrics{registry=" + registry + '}';
@@ -179,6 +195,132 @@ public final class ReservedConflictMetrics {
         public DoubleBuilder int_(@Safe String int_) {
             Preconditions.checkState(this.int_ == null, "int is already set");
             this.int_ = Preconditions.checkNotNull(int_, "int is required");
+            return this;
+        }
+    }
+
+    public interface IncludesDefaultTagsBuildStage {
+        @CheckReturnValue
+        Meter build();
+    }
+
+    public interface IncludesDefaultTagsBuilderJavaVersionStage {
+        @CheckReturnValue
+        IncludesDefaultTagsBuilderLibraryNameStage javaVersion(@Safe String javaVersion);
+    }
+
+    public interface IncludesDefaultTagsBuilderLibraryNameStage {
+        @CheckReturnValue
+        IncludesDefaultTagsBuilderLibraryVersionStage libraryName(@Safe String libraryName);
+    }
+
+    public interface IncludesDefaultTagsBuilderLibraryVersionStage {
+        @CheckReturnValue
+        IncludesDefaultTagsBuildStage libraryVersion(@Safe String libraryVersion);
+    }
+
+    private final class IncludesDefaultTagsBuilder
+            implements IncludesDefaultTagsBuilderJavaVersionStage,
+                    IncludesDefaultTagsBuilderLibraryNameStage,
+                    IncludesDefaultTagsBuilderLibraryVersionStage,
+                    IncludesDefaultTagsBuildStage {
+        private String javaVersion;
+
+        private String libraryName;
+
+        private String libraryVersion;
+
+        @Override
+        public Meter build() {
+            return registry.meter(MetricName.builder()
+                    .safeName("reserved.conflict.includes.default.tags")
+                    .putSafeTags("javaVersion", javaVersion)
+                    .putSafeTags("libraryName", libraryName)
+                    .putSafeTags("libraryVersion", libraryVersion)
+                    .build());
+        }
+
+        @Override
+        public IncludesDefaultTagsBuilder javaVersion(@Safe String javaVersion) {
+            Preconditions.checkState(this.javaVersion == null, "javaVersion is already set");
+            this.javaVersion = Preconditions.checkNotNull(javaVersion, "javaVersion is required");
+            return this;
+        }
+
+        @Override
+        public IncludesDefaultTagsBuilder libraryName(@Safe String libraryName) {
+            Preconditions.checkState(this.libraryName == null, "libraryName is already set");
+            this.libraryName = Preconditions.checkNotNull(libraryName, "libraryName is required");
+            return this;
+        }
+
+        @Override
+        public IncludesDefaultTagsBuilder libraryVersion(@Safe String libraryVersion) {
+            Preconditions.checkState(this.libraryVersion == null, "libraryVersion is already set");
+            this.libraryVersion = Preconditions.checkNotNull(libraryVersion, "libraryVersion is required");
+            return this;
+        }
+    }
+
+    public interface IncludesDefaultTagsDifferentCaseBuildStage {
+        @CheckReturnValue
+        Meter build();
+    }
+
+    public interface IncludesDefaultTagsDifferentCaseBuilderJavaversionStage {
+        @CheckReturnValue
+        IncludesDefaultTagsDifferentCaseBuilderLibrarynameStage javaversion(@Safe String javaversion);
+    }
+
+    public interface IncludesDefaultTagsDifferentCaseBuilderLibrarynameStage {
+        @CheckReturnValue
+        IncludesDefaultTagsDifferentCaseBuilderLibraryversionStage libraryname(@Safe String libraryname);
+    }
+
+    public interface IncludesDefaultTagsDifferentCaseBuilderLibraryversionStage {
+        @CheckReturnValue
+        IncludesDefaultTagsDifferentCaseBuildStage libraryversion(@Safe String libraryversion);
+    }
+
+    private final class IncludesDefaultTagsDifferentCaseBuilder
+            implements IncludesDefaultTagsDifferentCaseBuilderJavaversionStage,
+                    IncludesDefaultTagsDifferentCaseBuilderLibrarynameStage,
+                    IncludesDefaultTagsDifferentCaseBuilderLibraryversionStage,
+                    IncludesDefaultTagsDifferentCaseBuildStage {
+        private String javaversion;
+
+        private String libraryname;
+
+        private String libraryversion;
+
+        @Override
+        public Meter build() {
+            return registry.meter(MetricName.builder()
+                    .safeName("reserved.conflict.includes.default.tags.different.case")
+                    .putSafeTags("javaversion", javaversion)
+                    .putSafeTags("libraryname", libraryname)
+                    .putSafeTags("libraryversion", libraryversion)
+                    .build());
+        }
+
+        @Override
+        public IncludesDefaultTagsDifferentCaseBuilder javaversion(@Safe String javaversion) {
+            Preconditions.checkState(this.javaversion == null, "javaversion is already set");
+            this.javaversion = Preconditions.checkNotNull(javaversion, "javaversion is required");
+            return this;
+        }
+
+        @Override
+        public IncludesDefaultTagsDifferentCaseBuilder libraryname(@Safe String libraryname) {
+            Preconditions.checkState(this.libraryname == null, "libraryname is already set");
+            this.libraryname = Preconditions.checkNotNull(libraryname, "libraryname is required");
+            return this;
+        }
+
+        @Override
+        public IncludesDefaultTagsDifferentCaseBuilder libraryversion(@Safe String libraryversion) {
+            Preconditions.checkState(this.libraryversion == null, "libraryversion is already set");
+            this.libraryversion = Preconditions.checkNotNull(libraryversion, "libraryversion is required");
             return this;
         }
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -13,6 +13,8 @@ import java.util.Objects;
  * General web server metrics.
  */
 public final class ServerMetrics {
+    private static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+
     private static final String LIBRARY_NAME = "witchcraft";
 
     private static final String LIBRARY_VERSION =
@@ -48,6 +50,7 @@ public final class ServerMetrics {
                 .safeName("server.worker.utilization")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
                 .build();
     }
 
@@ -85,6 +88,7 @@ public final class ServerMetrics {
                     .putSafeTags("endpoint", endpoint)
                     .putSafeTags("libraryName", LIBRARY_NAME)
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
                     .build());
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -13,6 +13,8 @@ import java.util.Objects;
  * Tests we respect javaVisibility
  */
 final class VisibilityMetrics {
+    private static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+
     private static final String LIBRARY_NAME = "witchcraft";
 
     private static final String LIBRARY_VERSION =
@@ -37,6 +39,7 @@ final class VisibilityMetrics {
                 .safeName("visibility.test")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
                 .build());
     }
 
@@ -87,6 +90,7 @@ final class VisibilityMetrics {
                     .putSafeTags("bar", bar)
                     .putSafeTags("libraryName", LIBRARY_NAME)
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
                     .build();
         }
 

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
@@ -23,14 +23,18 @@ import javax.lang.model.SourceVersion;
 /** Field and parameter names used by this generator. */
 final class ReservedNames {
 
-    static final String LIBRARY_NAME = "LIBRARY_NAME";
-    static final String LIBRARY_VERSION = "LIBRARY_VERSION";
+    static final String LIBRARY_NAME_FIELD = "LIBRARY_NAME";
+    static final String LIBRARY_NAME_TAG = "libraryName";
+    static final String LIBRARY_VERSION_FIELD = "LIBRARY_VERSION";
+    static final String LIBRARY_VERSION_TAG = "libraryVersion";
+    static final String JAVA_VERSION_FIELD = "JAVA_VERSION";
+    static final String JAVA_VERSION_TAG = "javaVersion";
     static final String FACTORY_METHOD = "of";
     static final String GAUGE_NAME = "gauge";
     static final String REGISTRY_NAME = "registry";
 
-    private static final ImmutableSet<String> RESERVED_NAMES =
-            ImmutableSet.of(FACTORY_METHOD, GAUGE_NAME, REGISTRY_NAME, LIBRARY_NAME, LIBRARY_VERSION);
+    private static final ImmutableSet<String> RESERVED_NAMES = ImmutableSet.of(
+            FACTORY_METHOD, GAUGE_NAME, JAVA_VERSION_FIELD, LIBRARY_NAME_FIELD, LIBRARY_VERSION_FIELD, REGISTRY_NAME);
 
     /** Returns true if the input string cannot be used. */
     static boolean isValid(String input) {

--- a/metric-schema-java/src/test/java/com/palantir/metric/schema/JavaGeneratorTest.java
+++ b/metric-schema-java/src/test/java/com/palantir/metric/schema/JavaGeneratorTest.java
@@ -22,10 +22,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.metric.schema.lang.MetricSchemaCompiler;
+import com.palantir.test.MonitorsMetrics;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.MetricName;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,6 +63,14 @@ public class JavaGeneratorTest {
                 .map(Path::toString)
                 .forEach(relativePath ->
                         assertThatFilesAreTheSame(outputDir.resolve(relativePath), REFERENCE_FILES_FOLDER));
+    }
+
+    @Test
+    public void testJavaVersionTag() {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        MonitorsMetrics.of(registry).more("value").mark();
+        MetricName key = Iterables.getOnlyElement(registry.getMetrics().keySet());
+        assertThat(key.safeTags().get("javaVersion")).matches("\\d+\\.\\d+\\.\\d+");
     }
 
     private void assertThatFilesAreTheSame(Path outputFile, String referenceFilesFolder) {

--- a/metric-schema-java/src/test/resources/reserved-words.yml
+++ b/metric-schema-java/src/test/resources/reserved-words.yml
@@ -22,3 +22,11 @@ namespaces:
         tags:
           - int
         docs: Gauge metric with a single tag.
+      includes.default.tags:
+        type: meter
+        tags: [ javaVersion, libraryName, libraryVersion ]
+        docs: docs.
+      includes.default.tags.different.case:
+        type: meter
+        tags: [ javaversion, libraryname, libraryversion ]
+        docs: docs.


### PR DESCRIPTION
## Before this PR
It was difficult to tie changes in performance or stability to a particular java release due to lack of data association.

## After this PR
Note that I biased toward safety, excluding the new tag in cases where a `javaVersion` tag is already defined to avoid impacting existing dashboards, allowing upgrades to flow seamlessly.

==COMMIT_MSG==
metric-schema includes the java version by default as a `javaVersion` tag, for example `javaVersion:17.0.3`
==COMMIT_MSG==

## Possible downsides?
Reported metrics are slightly larger, but the cardinality is unchanged.
System property load on class initialization isn't quite as nice as loading the java version once in a library and referencing it elsewhere, however this isn't going to be meaningful overall.

I'd considered adding this data in the reporting layer, however by adding it higher up in the process, it's clearer what data we produce.