### PR TITLE
Allow to specify namespace tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ namespaces:
   my.service:
     # Documentation describing the entire namespace.
     docs: Metrics helpful for monitoring a my-service instance.
+    tags:
+      # Namespace tags will get automatically propagated to all child metrics and are checked for duplicates.
+      - operationType
     metrics:
       # Results in a meter with name `my.service.failures`
       failures:

--- a/changelog/@unreleased/pr-840.v2.yml
+++ b/changelog/@unreleased/pr-840.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Allow to specify namespace tags.
+  links:
+  - https://github.com/palantir/metric-schema/pull/840

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -133,7 +133,7 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         then:
         def result = runTasksWithFailure('classes')
         result.wasExecuted(':compileMetricSchema')
-        Throwables.getRootCause(result.getFailure()).getMessage().contains("tags must match pattern")
+        Throwables.getRootCause(result.getFailure()).getMessage().contains("tags names must match pattern")
     }
 
     def 'missing definition results in task failure'() {

--- a/metric-schema-api/build.gradle
+++ b/metric-schema-api/build.gradle
@@ -20,6 +20,12 @@ apply plugin: 'com.palantir.external-publish-conjure'
 conjure {
     java {
         strictObjects = true
+        // Avoid breaking strict consumers when new
+        // optional components are provided. Strict
+        // consumers will fail to deserialize once
+        // new features are used.
+        excludeEmptyOptionals = true
+        excludeEmptyCollections = true
     }
 }
 

--- a/metric-schema-api/src/main/conjure/metric-schema-api.yml
+++ b/metric-schema-api/src/main/conjure/metric-schema-api.yml
@@ -17,6 +17,7 @@ types:
             docs: A short name describing the metrics. Used to construct the name of the generated utility class.
             type: optional<string>
           docs: Documentation
+          tags: list<TagDefinition>
           metrics:
             type: map<string,MetricDefinition>
       MetricDefinition:

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -6,8 +6,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -23,21 +21,27 @@ public final class NamespaceTagsMetrics {
 
     private final TaggedMetricRegistry registry;
 
-    private final Map<String, String> tags;
+    private final String noValueTag;
 
-    private NamespaceTagsMetrics(TaggedMetricRegistry registry, Map<String, String> tags) {
+    private final NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues;
+
+    private NamespaceTagsMetrics(
+            TaggedMetricRegistry registry,
+            String noValueTag,
+            NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
         this.registry = registry;
-        this.tags = tags;
+        this.noValueTag = noValueTag;
+        this.locatorWithMultipleValues = locatorWithMultipleValues;
     }
 
     public static NamespaceTagsMetrics of(
             TaggedMetricRegistry registry,
             String noValueTag,
             NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
-        Map<String, String> tags = new HashMap<>();
-        tags.put("noValueTag", noValueTag);
-        tags.put("locatorWithMultipleValues", locatorWithMultipleValues.getValue());
-        return new NamespaceTagsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"), tags);
+        return new NamespaceTagsMetrics(
+                Preconditions.checkNotNull(registry, "TaggedMetricRegistry"),
+                Preconditions.checkNotNull(noValueTag, "noValueTag"),
+                Preconditions.checkNotNull(locatorWithMultipleValues, "locatorWithMultipleValues"));
     }
 
     /**
@@ -55,8 +59,9 @@ public final class NamespaceTagsMetrics {
     public Meter more() {
         return registry.meter(MetricName.builder()
                 .safeName("namespace-tags.more")
-                .putAllSafeTags(tags)
                 .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTag)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues.getValue())
                 .putSafeTags("otherLocator2", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
@@ -155,8 +160,9 @@ public final class NamespaceTagsMetrics {
         public Meter build() {
             return registry.meter(MetricName.builder()
                     .safeName("namespace-tags.processing")
-                    .putAllSafeTags(tags)
                     .putSafeTags("locator", "package:identifier")
+                    .putSafeTags("noValueTag", noValueTag)
+                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues.getValue())
                     .putSafeTags("result", result.getValue())
                     .putSafeTags("type", type)
                     .putSafeTags("otherLocator", otherLocator.getValue())

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -35,7 +35,6 @@ public final class NamespaceTagsMetrics {
             String noValueTag,
             NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
         Map<String, String> tags = new HashMap<>();
-        tags.put("locator", "package:identifier");
         tags.put("noValueTag", noValueTag);
         tags.put("locatorWithMultipleValues", locatorWithMultipleValues.getValue());
         return new NamespaceTagsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"), tags);
@@ -57,6 +56,7 @@ public final class NamespaceTagsMetrics {
         return registry.meter(MetricName.builder()
                 .safeName("namespace-tags.more")
                 .putAllSafeTags(tags)
+                .putSafeTags("locator", "package:identifier")
                 .putSafeTags("otherLocator2", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
@@ -156,6 +156,7 @@ public final class NamespaceTagsMetrics {
             return registry.meter(MetricName.builder()
                     .safeName("namespace-tags.processing")
                     .putAllSafeTags(tags)
+                    .putSafeTags("locator", "package:identifier")
                     .putSafeTags("result", result.getValue())
                     .putSafeTags("type", type)
                     .putSafeTags("otherLocator", otherLocator.getValue())

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -107,7 +107,7 @@ public final class NamespaceTagsMetrics {
                 @Safe NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues);
     }
 
-    private final class NamespaceTagsBuilder
+    private static final class NamespaceTagsBuilder
             implements NamespaceTagsBuilderRegistryStage,
                     NamespaceTagsBuilderNoValueTagStage,
                     NamespaceTagsBuilderLocatorWithMultipleValuesStage,

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -23,7 +23,7 @@ public final class NamespaceTagsMetrics {
 
     private final String noValueTag;
 
-    private final NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues;
+    private final String locatorWithMultipleValues;
 
     private NamespaceTagsMetrics(
             TaggedMetricRegistry registry,
@@ -31,7 +31,7 @@ public final class NamespaceTagsMetrics {
             NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
         this.registry = registry;
         this.noValueTag = noValueTag;
-        this.locatorWithMultipleValues = locatorWithMultipleValues;
+        this.locatorWithMultipleValues = locatorWithMultipleValues.getValue();
     }
 
     public static NamespaceTagsMetrics of(
@@ -61,7 +61,7 @@ public final class NamespaceTagsMetrics {
                 .safeName("namespace-tags.more")
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("noValueTag", noValueTag)
-                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues.getValue())
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
                 .putSafeTags("otherLocator2", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
@@ -71,7 +71,8 @@ public final class NamespaceTagsMetrics {
 
     @Override
     public String toString() {
-        return "NamespaceTagsMetrics{registry=" + registry + '}';
+        return "NamespaceTagsMetrics{registry=" + registry + ", locator=package:identifier" + ", noValueTag="
+                + noValueTag + ", locatorWithMultipleValues=" + locatorWithMultipleValues + '}';
     }
 
     public enum NamespaceTags_LocatorWithMultipleValues {
@@ -162,7 +163,7 @@ public final class NamespaceTagsMetrics {
                     .safeName("namespace-tags.processing")
                     .putSafeTags("locator", "package:identifier")
                     .putSafeTags("noValueTag", noValueTag)
-                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues.getValue())
+                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
                     .putSafeTags("result", result.getValue())
                     .putSafeTags("type", type)
                     .putSafeTags("otherLocator", otherLocator.getValue())

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -1,0 +1,158 @@
+package com.palantir.test;
+
+import com.codahale.metrics.Meter;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Objects;
+
+/**
+ * General web server metrics.
+ */
+public final class NamespaceTagsMetrics {
+    private static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+
+    private static final String LIBRARY_NAME = "witchcraft";
+
+    private static final String LIBRARY_VERSION =
+            Objects.requireNonNullElse(NamespaceTagsMetrics.class.getPackage().getImplementationVersion(), "unknown");
+
+    private final TaggedMetricRegistry registry;
+
+    private NamespaceTagsMetrics(TaggedMetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    public static NamespaceTagsMetrics of(TaggedMetricRegistry registry) {
+        return new NamespaceTagsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
+    }
+
+    /**
+     * Measures number of installations that were processed
+     */
+    @CheckReturnValue
+    public ProcessingBuilderResultStage processing() {
+        return new ProcessingBuilder();
+    }
+
+    /**
+     * Measures more
+     */
+    @CheckReturnValue
+    public Meter more() {
+        return registry.meter(MetricName.builder()
+                .safeName("namespace-tags.more")
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build());
+    }
+
+    @Override
+    public String toString() {
+        return "NamespaceTagsMetrics{registry=" + registry + '}';
+    }
+
+    public enum Processing_Result {
+        SUCCESS("success"),
+
+        FAILURE("failure");
+
+        private final String value;
+
+        Processing_Result(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
+    public enum Processing_OtherLocator {
+        PACKAGE_IDENTIFIER("package:identifier"),
+
+        PACKAGE_IDENTIFIER2("package:identifier2");
+
+        private final String value;
+
+        Processing_OtherLocator(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
+    public interface ProcessingBuildStage {
+        @CheckReturnValue
+        Meter build();
+    }
+
+    public interface ProcessingBuilderResultStage {
+        /**
+         * The result of processing
+         */
+        @CheckReturnValue
+        ProcessingBuilderTypeStage result(@Safe Processing_Result result);
+    }
+
+    public interface ProcessingBuilderTypeStage {
+        @CheckReturnValue
+        ProcessingBuilderOtherLocatorStage type(@Safe String type);
+    }
+
+    public interface ProcessingBuilderOtherLocatorStage {
+        @CheckReturnValue
+        ProcessingBuildStage otherLocator(@Safe Processing_OtherLocator otherLocator);
+    }
+
+    private final class ProcessingBuilder
+            implements ProcessingBuilderResultStage,
+                    ProcessingBuilderTypeStage,
+                    ProcessingBuilderOtherLocatorStage,
+                    ProcessingBuildStage {
+        private Processing_Result result;
+
+        private String type;
+
+        private Processing_OtherLocator otherLocator;
+
+        @Override
+        public Meter build() {
+            return registry.meter(MetricName.builder()
+                    .safeName("namespace-tags.processing")
+                    .putSafeTags("result", result.getValue())
+                    .putSafeTags("type", type)
+                    .putSafeTags("otherLocator", otherLocator.getValue())
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
+                    .build());
+        }
+
+        @Override
+        public ProcessingBuilder result(@Safe Processing_Result result) {
+            Preconditions.checkState(this.result == null, "result is already set");
+            this.result = Preconditions.checkNotNull(result, "result is required");
+            return this;
+        }
+
+        @Override
+        public ProcessingBuilder type(@Safe String type) {
+            Preconditions.checkState(this.type == null, "type is already set");
+            this.type = Preconditions.checkNotNull(type, "type is required");
+            return this;
+        }
+
+        @Override
+        public ProcessingBuilder otherLocator(@Safe Processing_OtherLocator otherLocator) {
+            Preconditions.checkState(this.otherLocator == null, "otherLocator is already set");
+            this.otherLocator = Preconditions.checkNotNull(otherLocator, "otherLocator is required");
+            return this;
+        }
+    }
+}

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -30,9 +30,14 @@ public final class NamespaceTagsMetrics {
         this.tags = tags;
     }
 
-    public static NamespaceTagsMetrics of(TaggedMetricRegistry registry, String locator) {
+    public static NamespaceTagsMetrics of(
+            TaggedMetricRegistry registry,
+            String noValueTag,
+            NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
         Map<String, String> tags = new HashMap<>();
-        tags.put("locator", locator);
+        tags.put("locator", "package:identifier");
+        tags.put("noValueTag", noValueTag);
+        tags.put("locatorWithMultipleValues", locatorWithMultipleValues.getValue());
         return new NamespaceTagsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"), tags);
     }
 
@@ -51,6 +56,8 @@ public final class NamespaceTagsMetrics {
     public Meter more() {
         return registry.meter(MetricName.builder()
                 .safeName("namespace-tags.more")
+                .putAllSafeTags(tags)
+                .putSafeTags("otherLocator2", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
@@ -60,6 +67,22 @@ public final class NamespaceTagsMetrics {
     @Override
     public String toString() {
         return "NamespaceTagsMetrics{registry=" + registry + '}';
+    }
+
+    public enum NamespaceTags_LocatorWithMultipleValues {
+        PACKAGE_IDENTIFIER("package:identifier"),
+
+        PACKAGE_IDENTIFIER2("package:identifier2");
+
+        private final String value;
+
+        NamespaceTags_LocatorWithMultipleValues(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
     }
 
     public enum Processing_Result {
@@ -132,6 +155,7 @@ public final class NamespaceTagsMetrics {
         public Meter build() {
             return registry.meter(MetricName.builder()
                     .safeName("namespace-tags.processing")
+                    .putAllSafeTags(tags)
                     .putSafeTags("result", result.getValue())
                     .putSafeTags("type", type)
                     .putSafeTags("otherLocator", otherLocator.getValue())

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -34,14 +34,9 @@ public final class NamespaceTagsMetrics {
         this.locatorWithMultipleValues = locatorWithMultipleValues.getValue();
     }
 
-    public static NamespaceTagsMetrics of(
-            TaggedMetricRegistry registry,
-            String noValueTag,
-            NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
-        return new NamespaceTagsMetrics(
-                Preconditions.checkNotNull(registry, "TaggedMetricRegistry"),
-                Preconditions.checkNotNull(noValueTag, "noValueTag"),
-                Preconditions.checkNotNull(locatorWithMultipleValues, "locatorWithMultipleValues"));
+    @CheckReturnValue
+    public NamespaceTagsBuilderRegistryStage builder() {
+        return new NamespaceTagsBuilder();
     }
 
     /**
@@ -88,6 +83,68 @@ public final class NamespaceTagsMetrics {
 
         private String getValue() {
             return value;
+        }
+    }
+
+    public interface NamespaceTagsBuildStage {
+        @CheckReturnValue
+        NamespaceTagsMetrics build();
+    }
+
+    public interface NamespaceTagsBuilderRegistryStage {
+        @CheckReturnValue
+        NamespaceTagsBuilderNoValueTagStage registry(@Safe TaggedMetricRegistry registry);
+    }
+
+    public interface NamespaceTagsBuilderNoValueTagStage {
+        @CheckReturnValue
+        NamespaceTagsBuilderLocatorWithMultipleValuesStage noValueTag(@Safe String noValueTag);
+    }
+
+    public interface NamespaceTagsBuilderLocatorWithMultipleValuesStage {
+        @CheckReturnValue
+        NamespaceTagsBuildStage locatorWithMultipleValues(
+                @Safe NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues);
+    }
+
+    private final class NamespaceTagsBuilder
+            implements NamespaceTagsBuilderRegistryStage,
+                    NamespaceTagsBuilderNoValueTagStage,
+                    NamespaceTagsBuilderLocatorWithMultipleValuesStage,
+                    NamespaceTagsBuildStage {
+        private TaggedMetricRegistry registry;
+
+        private String noValueTag;
+
+        private NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues;
+
+        @Override
+        public NamespaceTagsMetrics build() {
+            return new NamespaceTagsMetrics(registry, noValueTag, locatorWithMultipleValues);
+        }
+
+        @Override
+        public NamespaceTagsBuilder registry(@Safe TaggedMetricRegistry registry) {
+            Preconditions.checkState(this.registry == null, "registry is already set");
+            this.registry = Preconditions.checkNotNull(registry, "registry is required");
+            return this;
+        }
+
+        @Override
+        public NamespaceTagsBuilder noValueTag(@Safe String noValueTag) {
+            Preconditions.checkState(this.noValueTag == null, "noValueTag is already set");
+            this.noValueTag = Preconditions.checkNotNull(noValueTag, "noValueTag is required");
+            return this;
+        }
+
+        @Override
+        public NamespaceTagsBuilder locatorWithMultipleValues(
+                @Safe NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
+            Preconditions.checkState(
+                    this.locatorWithMultipleValues == null, "locatorWithMultipleValues is already set");
+            this.locatorWithMultipleValues =
+                    Preconditions.checkNotNull(locatorWithMultipleValues, "locatorWithMultipleValues is required");
+            return this;
         }
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -35,7 +35,7 @@ public final class NamespaceTagsMetrics {
     }
 
     @CheckReturnValue
-    public NamespaceTagsBuilderRegistryStage builder() {
+    public static NamespaceTagsBuilderRegistryStage builder() {
         return new NamespaceTagsBuilder();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -6,6 +6,8 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -21,12 +23,17 @@ public final class NamespaceTagsMetrics {
 
     private final TaggedMetricRegistry registry;
 
-    private NamespaceTagsMetrics(TaggedMetricRegistry registry) {
+    private final Map<String, String> tags;
+
+    private NamespaceTagsMetrics(TaggedMetricRegistry registry, Map<String, String> tags) {
         this.registry = registry;
+        this.tags = tags;
     }
 
-    public static NamespaceTagsMetrics of(TaggedMetricRegistry registry) {
-        return new NamespaceTagsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
+    public static NamespaceTagsMetrics of(TaggedMetricRegistry registry, String locator) {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("locator", locator);
+        return new NamespaceTagsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"), tags);
     }
 
     /**

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Custodian.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Custodian.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /** Utility functionality to escape metric values for generated java code. */
-public final class Custodian {
+final class Custodian {
 
     private static final Splitter splitter =
             Splitter.onPattern("[^a-zA-Z0-9]").trimResults().omitEmptyStrings();
@@ -35,7 +35,7 @@ public final class Custodian {
         return escapeIfNecessary(sanitized);
     }
 
-    public static String anyToUpperCamel(String input) {
+    static String anyToUpperCamel(String input) {
         Preconditions.checkNotNull(input, "Input string is required");
         return String.join(
                 "", CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.UPPER_CAMEL).convertAll(splitter.split(input)));

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Custodian.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Custodian.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /** Utility functionality to escape metric values for generated java code. */
-final class Custodian {
+public final class Custodian {
 
     private static final Splitter splitter =
             Splitter.onPattern("[^a-zA-Z0-9]").trimResults().omitEmptyStrings();
@@ -35,7 +35,7 @@ final class Custodian {
         return escapeIfNecessary(sanitized);
     }
 
-    static String anyToUpperCamel(String input) {
+    public static String anyToUpperCamel(String input) {
         Preconditions.checkNotNull(input, "Input string is required");
         return String.join(
                 "", CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.UPPER_CAMEL).convertAll(splitter.split(input)));

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/JavaGenerator.java
@@ -19,6 +19,7 @@ package com.palantir.metric.schema;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.goethe.Goethe;
+import com.palantir.metric.schema.model.ImplementationVisibility;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
@@ -30,8 +30,10 @@ final class ReservedNames {
     static final String JAVA_VERSION_FIELD = "JAVA_VERSION";
     static final String JAVA_VERSION_TAG = "javaVersion";
     static final String FACTORY_METHOD = "of";
+    static final String BUILDER_METHOD = "builder";
     static final String GAUGE_NAME = "gauge";
     static final String REGISTRY_NAME = "registry";
+    static final String TAGS = "tags";
 
     private static final ImmutableSet<String> RESERVED_NAMES = ImmutableSet.of(
             FACTORY_METHOD, GAUGE_NAME, JAVA_VERSION_FIELD, LIBRARY_NAME_FIELD, LIBRARY_VERSION_FIELD, REGISTRY_NAME);

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/ReservedNames.java
@@ -33,7 +33,6 @@ final class ReservedNames {
     static final String BUILDER_METHOD = "builder";
     static final String GAUGE_NAME = "gauge";
     static final String REGISTRY_NAME = "registry";
-    static final String TAGS = "tags";
 
     private static final ImmutableSet<String> RESERVED_NAMES = ImmutableSet.of(
             FACTORY_METHOD, GAUGE_NAME, JAVA_VERSION_FIELD, LIBRARY_NAME_FIELD, LIBRARY_VERSION_FIELD, REGISTRY_NAME);

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -265,7 +265,7 @@ final class UtilityGenerator {
                         .collect(ImmutableList.toImmutableList()))
                 .build());
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(ReservedNames.BUILDER_METHOD)
-                .addModifiers(stagedBuilderSpec.visibility().apply())
+                .addModifiers(stagedBuilderSpec.visibility().apply(Modifier.STATIC))
                 .returns(ClassName.bestGuess(stageName(
                         stagedBuilderSpec.name(),
                         stagedBuilderSpec.stages().get(0).name())))

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -30,7 +30,6 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.CodeBlock.Builder;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -377,7 +376,7 @@ final class UtilityGenerator {
         return builder.add(".build()").build();
     }
 
-    private static void putSafeTags(TagDefinition tagDef, Builder builder) {
+    private static void putSafeTags(TagDefinition tagDef, CodeBlock.Builder builder) {
         if (tagDef.getValues().isEmpty()) {
             builder.add(".putSafeTags($S, $L)", tagDef.getName(), Custodian.sanitizeName(tagDef.getName()));
         } else if (tagDef.getValues().size() == 1) {

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -192,7 +192,6 @@ final class UtilityGenerator {
                 .addModifiers(stagedBuilderSpec.visibility().apply())
                 .addMethods(abstractBuildMethods)
                 .build());
-
         for (int i = 0; i < stagedBuilderSpec.stages().size(); i++) {
             boolean lastTag = i == stagedBuilderSpec.stages().size() - 1;
             BuilderStage tag = stagedBuilderSpec.stages().get(i);

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -264,7 +264,7 @@ final class UtilityGenerator {
                                 .build())
                         .collect(ImmutableList.toImmutableList()))
                 .build());
-        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("builder")
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(ReservedNames.BUILDER_METHOD)
                 .addModifiers(stagedBuilderSpec.visibility().apply())
                 .returns(ClassName.bestGuess(stageName(
                         stagedBuilderSpec.name(),

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -33,7 +33,6 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
-import com.squareup.javapoet.TypeSpec.Builder;
 import com.squareup.javapoet.WildcardTypeName;
 import java.util.HashMap;
 import java.util.List;
@@ -206,8 +205,8 @@ final class UtilityGenerator {
     }
 
     private static void generateTagEnum(
-            Builder builder, String metricName, ImplementationVisibility visibility, TagDefinition tagDef) {
-        Builder enumBuilder = TypeSpec.enumBuilder(getTagClassName(metricName, tagDef));
+            TypeSpec.Builder builder, String metricName, ImplementationVisibility visibility, TagDefinition tagDef) {
+        TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(getTagClassName(metricName, tagDef));
         tagDef.getValues()
                 .forEach(value -> enumBuilder.addEnumConstant(
                         Custodian.anyToUpperUnderscore(value.getValue()),

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -177,6 +177,7 @@ final class UtilityGenerator {
                 .className(className1)
                 .constructor(buildBlock.build())
                 .visibility(visibility1)
+                .isStatic(true)
                 .addAllStages(builderStages)
                 .build();
 
@@ -224,8 +225,13 @@ final class UtilityGenerator {
                 .addCode("return ")
                 .addCode(stagedBuilderSpec.constructor());
         MethodSpec buildMethod = buildMethodBuilder.build();
+        List<Modifier> modifiers = new ArrayList<>();
+        modifiers.addAll(List.of(Modifier.PRIVATE, Modifier.FINAL));
+        if (stagedBuilderSpec.isStatic()) {
+            modifiers.add(Modifier.STATIC);
+        }
         outerBuilder.addType(TypeSpec.classBuilder(Custodian.anyToUpperCamel(stagedBuilderSpec.name()) + "Builder")
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .addModifiers(modifiers.toArray(new Modifier[0]))
                 .addSuperinterfaces(stagedBuilderSpec.stages().stream()
                         .map(stage -> ClassName.bestGuess(stageName(stagedBuilderSpec.name(), stage.name())))
                         .collect(ImmutableList.toImmutableList()))

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -153,10 +153,11 @@ final class UtilityGenerator {
                     builder.addStatement(
                             "tags.put($S, $L)", tagDef.getName(), Custodian.sanitizeName(tagDef.getName()));
                 } else if (tagDef.getValues().size() == 1) {
-                    builder.addStatement(
-                            "tags.put($S, $S)",
-                            tagDef.getName(),
-                            Iterables.getOnlyElement(tagDef.getValues()).getValue());
+                    // Ignore: each metricName build should add this manually.
+                    //                    builder.addStatement(
+                    //                            "tags.put($S, $S)",
+                    //                            tagDef.getName(),
+                    //                            Iterables.getOnlyElement(tagDef.getValues()).getValue());
                 } else {
                     builder.addStatement(
                             "tags.put($S, $L.getValue())", tagDef.getName(), Custodian.sanitizeName(tagDef.getName()));
@@ -243,6 +244,15 @@ final class UtilityGenerator {
         if (!metricNamespace.getTags().isEmpty()) {
             builder.add(".putAllSafeTags($L)", ReservedNames.TAGS);
         }
+        metricNamespace.getTags().forEach(tagDef -> {
+            if (tagDef.getValues().size() == 1) {
+                builder.add(
+                        ".putSafeTags($S, $S)",
+                        tagDef.getName(),
+                        Iterables.getOnlyElement(tagDef.getValues()).getValue());
+            }
+        });
+
         definition.getTagDefinitions().forEach(tagDef -> {
             if (tagDef.getValues().isEmpty()) {
                 builder.add(".putSafeTags($S, $L)", tagDef.getName(), Custodian.sanitizeName(tagDef.getName()));

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/model/BuilderStage.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/model/BuilderStage.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema.model;
+
+import com.palantir.metric.schema.Documentation;
+import com.squareup.javapoet.ClassName;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutablesStagedStyle
+public interface BuilderStage {
+
+    String name();
+
+    String sanitizedName();
+
+    ClassName className();
+
+    Optional<Documentation> docs();
+
+    static ImmutableBuilderStage.NameBuildStage builder() {
+        return ImmutableBuilderStage.builder();
+    }
+}

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/model/ImmutablesStagedStyle.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/model/ImmutablesStagedStyle.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@Value.Style(
+        visibility = Value.Style.ImplementationVisibility.PACKAGE,
+        overshadowImplementation = true,
+        jdkOnly = true,
+        get = {"get*", "is*"},
+        stagedBuilder = true)
+public @interface ImmutablesStagedStyle {}

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/model/ImplementationVisibility.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/model/ImplementationVisibility.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.palantir.metric.schema;
+package com.palantir.metric.schema.model;
 
 import com.google.common.collect.ImmutableList;
 import javax.lang.model.element.Modifier;
 
-enum ImplementationVisibility {
+public enum ImplementationVisibility {
 
     /** Generated class will be public. */
     PUBLIC,
@@ -27,7 +27,7 @@ enum ImplementationVisibility {
     /** Generate class will be package private. */
     PACKAGE_PRIVATE;
 
-    static ImplementationVisibility fromString(String value) {
+    public static ImplementationVisibility fromString(String value) {
         if (value.equals("public")) {
             return PUBLIC;
         } else if (value.equals("packagePrivate")) {
@@ -36,7 +36,7 @@ enum ImplementationVisibility {
         throw new IllegalArgumentException();
     }
 
-    Modifier[] apply(Modifier... modifiers) {
+    public Modifier[] apply(Modifier... modifiers) {
         if (this == PUBLIC) {
             return ImmutableList.<Modifier>builderWithExpectedSize(modifiers.length + 1)
                     .add(Modifier.PUBLIC)

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/model/StagedBuilderSpec.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/model/StagedBuilderSpec.java
@@ -39,6 +39,8 @@ public interface StagedBuilderSpec {
 
     Optional<Documentation> docs();
 
+    boolean isStatic();
+
     static ImmutableStagedBuilderSpec.NameBuildStage builder() {
         return ImmutableStagedBuilderSpec.builder();
     }

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/model/StagedBuilderSpec.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/model/StagedBuilderSpec.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema.model;
+
+import com.palantir.metric.schema.Documentation;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutablesStagedStyle
+public interface StagedBuilderSpec {
+
+    String name();
+
+    ClassName className();
+
+    CodeBlock constructor();
+
+    ImplementationVisibility visibility();
+
+    List<BuilderStage> stages();
+
+    Optional<Documentation> docs();
+
+    static ImmutableStagedBuilderSpec.NameBuildStage builder() {
+        return ImmutableStagedBuilderSpec.builder();
+    }
+}

--- a/metric-schema-java/src/test/resources/namespace-tags.yml
+++ b/metric-schema-java/src/test/resources/namespace-tags.yml
@@ -4,6 +4,9 @@ namespaces:
     tags:
       - name: locator
         values: [ package:identifier ]
+      - noValueTag
+      - name: locatorWithMultipleValues
+        values: [ package:identifier, package:identifier2 ]
     metrics:
       processing:
         docs: Measures number of installations that were processed
@@ -18,3 +21,6 @@ namespaces:
       more:
         docs: Measures more
         type: meter
+        tags:
+          - name: otherLocator2
+            values: [ package:identifier ]

--- a/metric-schema-java/src/test/resources/namespace-tags.yml
+++ b/metric-schema-java/src/test/resources/namespace-tags.yml
@@ -1,0 +1,20 @@
+namespaces:
+  namespace-tags:
+    docs: General web server metrics.
+    tags:
+      - name: locator
+        values: [ package:identifier ]
+    metrics:
+      processing:
+        docs: Measures number of installations that were processed
+        type: meter
+        tags:
+          - name: result
+            docs: The result of processing
+            values: [success, failure]
+          - type
+          - name: otherLocator
+            values: [ package:identifier, package:identifier2 ]
+      more:
+        docs: Measures more
+        type: meter

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
@@ -24,6 +24,7 @@ import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.TagDefinition;
 import com.palantir.metric.schema.TagValue;
+import java.util.List;
 
 final class LangConverter {
     static MetricSchema toApi(LangMetricSchema schema) {
@@ -37,6 +38,7 @@ final class LangConverter {
         return MetricNamespace.builder()
                 .shortName(namespace.shortName())
                 .docs(Documentation.of(namespace.docs()))
+                .tags(convert(namespace.tags()))
                 .metrics(Maps.transformValues(namespace.metrics(), LangConverter::convert))
                 .build();
     }
@@ -44,17 +46,19 @@ final class LangConverter {
     private static MetricDefinition convert(LangMetricDefinition definition) {
         return MetricDefinition.builder()
                 .type(definition.type())
-                .tagDefinitions(definition.tags().stream()
-                        .map(tag -> TagDefinition.builder()
-                                .name(tag.name())
-                                .docs(tag.docs().map(Documentation::of))
-                                .values(tag.values().stream()
-                                        .map(TagValue::of)
-                                        .collect(ImmutableList.toImmutableList()))
-                                .build())
-                        .collect(ImmutableList.toImmutableList()))
+                .tagDefinitions(convert(definition.tags()))
                 .docs(Documentation.of(definition.docs()))
                 .build();
+    }
+
+    private static List<TagDefinition> convert(List<com.palantir.metric.schema.lang.TagDefinition> tags) {
+        return tags.stream()
+                .map(tag -> TagDefinition.builder()
+                        .name(tag.name())
+                        .docs(tag.docs().map(Documentation::of))
+                        .values(tag.values().stream().map(TagValue::of).collect(ImmutableList.toImmutableList()))
+                        .build())
+                .collect(ImmutableList.toImmutableList());
     }
 
     private LangConverter() {}

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangMetricNamespace.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangMetricNamespace.java
@@ -17,6 +17,7 @@
 package com.palantir.metric.schema.lang;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value.Immutable;
@@ -27,6 +28,8 @@ public interface LangMetricNamespace {
     Optional<String> shortName();
 
     String docs();
+
+    List<TagDefinition> tags();
 
     Map<String, LangMetricDefinition> metrics();
 }

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
@@ -80,6 +80,7 @@ final class Validator {
             Preconditions.checkArgument(
                     uniqueNames.size() == definition.getTagDefinitions().size(), "Encountered duplicate tag names");
             definition.getTagDefinitions().forEach(tag -> {
+                // TODO(jakubk): Check that tag names here are not clashing with the namespace tags.
                 Preconditions.checkArgument(
                         !tag.getName().isEmpty(),
                         "MetricDefinition tags must not be empty",

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
@@ -27,7 +27,6 @@ import com.palantir.metric.schema.MetricNamespace;
 import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.MetricType;
 import com.palantir.metric.schema.TagDefinition;
-import com.palantir.metric.schema.TagValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -127,13 +126,6 @@ final class Validator {
                             SafeArg.of("tag", tag.getName()),
                             SafeArg.of("tagValue", tagValue),
                             SafeArg.of("pattern", TAG_VALUE_PATTERN)));
-            Set<String> duplicates = getDuplicates(
-                    tag.getValues().stream().map(TagValue::getValue).collect(Collectors.toList()));
-            checkArgumentWithErrorContext(
-                    !duplicates.isEmpty(),
-                    "Encountered duplicate tag values",
-                    errorContext,
-                    SafeArg.of("duplicateTagValues", duplicates));
         });
     }
 

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
@@ -107,7 +107,7 @@ final class Validator {
                 .filter(namespaceTagNames::contains)
                 .collect(Collectors.toSet());
         checkArgumentWithErrorContext(
-                duplicateNames.isEmpty(),
+                duplicateNamespaceTagNames.isEmpty(),
                 "Encountered metric tag names that duplicate namespace tag names",
                 errorContext,
                 SafeArg.of("duplicateTagNames", duplicateNames),

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/Validator.java
@@ -16,6 +16,10 @@
 
 package com.palantir.metric.schema.lang;
 
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.metric.schema.Documentation;
@@ -24,6 +28,9 @@ import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.MetricType;
 import com.palantir.metric.schema.TagDefinition;
 import com.palantir.metric.schema.TagValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -57,6 +64,9 @@ final class Validator {
                 SafeArg.of("pattern", NAME_PATTERN));
         validateShortName(namespaceValue);
         validateDocumentation(namespaceValue.getDocs());
+
+        validateTagDefinitions(namespaceValue.getTags(), Set.of(), List.of(SafeArg.of("namespace", namespace)));
+
         namespaceValue.getMetrics().forEach((name, definition) -> {
             Preconditions.checkNotNull(definition, "MetricDefinition is required", SafeArg.of("namespace", namespace));
             Preconditions.checkArgument(
@@ -74,36 +84,64 @@ final class Validator {
             validateDocumentation(definition.getDocs());
             Preconditions.checkArgument(definition.getTags().isEmpty(), "tags field is replaced tagDefinition");
 
-            Set<String> uniqueNames = definition.getTagDefinitions().stream()
-                    .map(TagDefinition::getName)
-                    .collect(Collectors.toSet());
-            Preconditions.checkArgument(
-                    uniqueNames.size() == definition.getTagDefinitions().size(), "Encountered duplicate tag names");
-            definition.getTagDefinitions().forEach(tag -> {
-                // TODO(jakubk): Check that tag names here are not clashing with the namespace tags.
-                Preconditions.checkArgument(
-                        !tag.getName().isEmpty(),
-                        "MetricDefinition tags must not be empty",
-                        SafeArg.of("namespace", namespace),
-                        SafeArg.of("definition", definition));
-                Preconditions.checkArgument(
-                        NAME_PREDICATE.matcher(tag.getName()).matches(),
-                        "MetricDefinition tags must match pattern",
-                        SafeArg.of("pattern", NAME_PATTERN));
-                tag.getValues().forEach(tagValue -> {
-                    Preconditions.checkArgument(
+            validateTagDefinitions(
+                    definition.getTagDefinitions(),
+                    namespaceValue.getTags().stream()
+                            .map(TagDefinition::getName)
+                            .collect(Collectors.toSet()),
+                    List.of(SafeArg.of("namespace", namespace), SafeArg.of("definition", definition)));
+        });
+    }
+
+    private static void validateTagDefinitions(
+            List<TagDefinition> tagDefinition, Set<String> namespaceTagNames, List<SafeArg<?>> errorContext) {
+        Set<String> duplicateNames =
+                getDuplicates(tagDefinition.stream().map(TagDefinition::getName).collect(Collectors.toList()));
+        checkArgumentWithErrorContext(
+                duplicateNames.isEmpty(),
+                "Encountered duplicate tag names",
+                errorContext,
+                SafeArg.of("duplicateTagNames", duplicateNames));
+        Set<String> duplicateNamespaceTagNames = tagDefinition.stream()
+                .map(TagDefinition::getName)
+                .filter(namespaceTagNames::contains)
+                .collect(Collectors.toSet());
+        checkArgumentWithErrorContext(
+                duplicateNames.isEmpty(),
+                "Encountered metric tag names that duplicate namespace tag names",
+                errorContext,
+                SafeArg.of("duplicateTagNames", duplicateNames),
+                SafeArg.of("namespaceTagNames", namespaceTagNames));
+        tagDefinition.forEach(tag -> {
+            checkArgumentWithErrorContext(!tag.getName().isEmpty(), "tag name must not be empty", errorContext);
+            checkArgumentWithErrorContext(
+                    NAME_PREDICATE.matcher(tag.getName()).matches(),
+                    "tags names must match pattern",
+                    errorContext,
+                    SafeArg.of("pattern", NAME_PATTERN));
+            tag.getValues()
+                    .forEach(tagValue -> checkArgumentWithErrorContext(
                             TAG_VALUE_PREDICATE.matcher(tagValue.getValue()).matches(),
                             "tag values must match pattern",
+                            errorContext,
                             SafeArg.of("tag", tag.getName()),
                             SafeArg.of("tagValue", tagValue),
-                            SafeArg.of("pattern", TAG_VALUE_PATTERN));
-                });
-                Set<String> uniqueValues =
-                        tag.getValues().stream().map(TagValue::getValue).collect(Collectors.toSet());
-                Preconditions.checkArgument(
-                        uniqueValues.size() == tag.getValues().size(), "Encountered duplicate tag values");
-            });
+                            SafeArg.of("pattern", TAG_VALUE_PATTERN)));
+            Set<String> duplicates = getDuplicates(
+                    tag.getValues().stream().map(TagValue::getValue).collect(Collectors.toList()));
+            checkArgumentWithErrorContext(
+                    !duplicates.isEmpty(),
+                    "Encountered duplicate tag values",
+                    errorContext,
+                    SafeArg.of("duplicateTagValues", duplicates));
         });
+    }
+
+    private static Set<String> getDuplicates(List<String> values) {
+        Multiset<String> strings = HashMultiset.create(values);
+        return strings.elementSet().stream()
+                .filter(element -> strings.count(element) > 1)
+                .collect(Collectors.toSet());
     }
 
     private static void validateShortName(MetricNamespace namespace) {
@@ -118,6 +156,16 @@ final class Validator {
 
     private static void validateDocumentation(Documentation documentation) {
         Preconditions.checkArgument(StringUtils.isNotBlank(documentation.get()), "Documentation must not be blank");
+    }
+
+    private static void checkArgumentWithErrorContext(
+            boolean expression,
+            @CompileTimeConstant String message,
+            List<SafeArg<?>> errorContext,
+            SafeArg<?>... args) {
+        List<SafeArg<?>> allArgs = new ArrayList<>(Arrays.asList(args));
+        allArgs.addAll(errorContext);
+        Preconditions.checkArgument(expression, message, allArgs.toArray(new Arg[0]));
     }
 
     private Validator() {}

--- a/metric-schema-lang/src/test/java/com/palantir/metric/schema/lang/ValidatorTest.java
+++ b/metric-schema-lang/src/test/java/com/palantir/metric/schema/lang/ValidatorTest.java
@@ -126,7 +126,7 @@ class ValidatorTest {
                                         .build())
                         .build()))
                 .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessageContaining("MetricDefinition tags must not be empty");
+                .hasMessageContaining("tag name must not be empty");
     }
 
     @Test

--- a/metric-schema-lang/src/test/java/com/palantir/metric/schema/lang/ValidatorTest.java
+++ b/metric-schema-lang/src/test/java/com/palantir/metric/schema/lang/ValidatorTest.java
@@ -69,6 +69,22 @@ class ValidatorTest {
     }
 
     @Test
+    void testValidateNamespaceTags_duplicate() {
+        TagDefinition tagName = TagDefinition.builder().name("tagName").build();
+        assertThatThrownBy(() -> Validator.validate(MetricSchema.builder()
+                        .namespaces(
+                                "test",
+                                MetricNamespace.builder()
+                                        .tags(tagName)
+                                        .tags(tagName)
+                                        .docs(DOCS)
+                                        .build())
+                        .build()))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Encountered duplicate tag names");
+    }
+
+    @Test
     void testEmptyMetricName() {
         assertThatThrownBy(() -> Validator.validate(MetricSchema.builder()
                         .namespaces(
@@ -212,5 +228,51 @@ class ValidatorTest {
                                         .build())
                         .build()))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testValidateMetricTag_duplicateName() {
+        TagDefinition tagDefinition =
+                TagDefinition.builder().name("tagDefinition").build();
+        assertThatThrownBy(() -> Validator.validate(MetricSchema.builder()
+                        .namespaces(
+                                "test",
+                                MetricNamespace.builder()
+                                        .docs(DOCS)
+                                        .metrics(
+                                                "metric",
+                                                MetricDefinition.builder()
+                                                        .docs(DOCS)
+                                                        .type(MetricType.COUNTER)
+                                                        .tagDefinitions(tagDefinition)
+                                                        .tagDefinitions(tagDefinition)
+                                                        .build())
+                                        .build())
+                        .build()))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Encountered duplicate tag names");
+    }
+
+    @Test
+    void testValidateMetricTag_metricTagNameDuplicatesNamespaceTagName() {
+        TagDefinition tagDefinition =
+                TagDefinition.builder().name("tagDefinition").build();
+        assertThatThrownBy(() -> Validator.validate(MetricSchema.builder()
+                        .namespaces(
+                                "test",
+                                MetricNamespace.builder()
+                                        .docs(DOCS)
+                                        .tags(tagDefinition)
+                                        .metrics(
+                                                "metric",
+                                                MetricDefinition.builder()
+                                                        .docs(DOCS)
+                                                        .type(MetricType.COUNTER)
+                                                        .tagDefinitions(tagDefinition)
+                                                        .build())
+                                        .build())
+                        .build()))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Encountered metric tag names that duplicate namespace tag names");
     }
 }

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -194,6 +194,9 @@ class MarkdownRendererTest {
                         "namespace",
                         MetricNamespace.builder()
                                 .docs(Documentation.of("namespace docs"))
+                                .tags(TagDefinition.builder()
+                                        .name("namespaceTag")
+                                        .build())
                                 .metrics(
                                         "metric",
                                         MetricDefinition.builder()
@@ -223,6 +226,7 @@ class MarkdownRendererTest {
                         + "### namespace\n"
                         + "namespace docs\n"
                         + "- `namespace.metric` (meter): metric docs\n"
+                        + "  - `namespaceTag`\n"
                         + "  - `result` values (`failure`,`success`)\n"
                         + "  - `endpoint`: Some docs");
     }


### PR DESCRIPTION
## Before this PR

There are usecases where namespaces group metrics which should have the same tags applied to all of them. Right now the solution is to copy-pasta 🍝  the tags into all the metrics. We can probably do better than that.

TODO:

- [x] toString.
- [x] Pass and assign variables in constructor.
- [x] Generate enums.
- [x] Add namespace tags to metric tags.
- [x] Staged builder.
- [x] Validation.
- [x] Markdown generation.
- [x] README

## After this PR
==COMMIT_MSG==
Allow to specify namespace tags.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->