### PR TITLE
Fix gauge metric name if namespace tags are present.

### DIFF
--- a/changelog/@unreleased/pr-841.v2.yml
+++ b/changelog/@unreleased/pr-841.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix gauges when namespace tags are applied.
+  links:
+  - https://github.com/palantir/metric-schema/pull/841

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -1,5 +1,6 @@
 package com.palantir.test;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
@@ -62,6 +63,25 @@ public final class NamespaceTagsMetrics {
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
                 .build());
+    }
+
+    /**
+     * Gauges something
+     */
+    public void gauges(Gauge<?> gauge) {
+        registry.registerWithReplacement(gaugesMetricName(), gauge);
+    }
+
+    public MetricName gaugesMetricName() {
+        return MetricName.builder()
+                .safeName("namespace-tags.gauges")
+                .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTag)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build();
     }
 
     @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -1,7 +1,10 @@
 package com.palantir.test;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
@@ -49,11 +52,11 @@ public final class NamespaceTagsMetrics {
     }
 
     /**
-     * Measures more
+     * Counts something
      */
     @CheckReturnValue
-    public Meter more() {
-        return registry.meter(MetricName.builder()
+    public Counter more() {
+        return registry.counter(MetricName.builder()
                 .safeName("namespace-tags.more")
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("noValueTag", noValueTag)
@@ -82,6 +85,38 @@ public final class NamespaceTagsMetrics {
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
                 .build();
+    }
+
+    /**
+     * Times something
+     */
+    @CheckReturnValue
+    public Timer times() {
+        return registry.timer(MetricName.builder()
+                .safeName("namespace-tags.times")
+                .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTag)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build());
+    }
+
+    /**
+     * Histograms something
+     */
+    @CheckReturnValue
+    public Histogram histograms() {
+        return registry.histogram(MetricName.builder()
+                .safeName("namespace-tags.histograms")
+                .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTag)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build());
     }
 
     @Override

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -450,9 +450,10 @@ final class UtilityGenerator {
                 .addJavadoc(Javadoc.render(definition.getDocs()));
 
         CodeBlock metricNameBlock = metricName(namespace, metricName, libraryName, definition, metricNamespace);
+        List<Modifier> extraModifiers = metricNamespace.getTags().isEmpty() ? List.of(Modifier.STATIC) : List.of();
         MethodSpec metricNameMethod = MethodSpec.methodBuilder(Custodian.sanitizeName(metricName + "MetricName"))
                 .addModifiers(visibility.apply())
-                .addModifiers(Modifier.STATIC)
+                .addModifiers(extraModifiers.toArray(new Modifier[0]))
                 .returns(MetricName.class)
                 .addCode("return $L;", metricNameBlock)
                 .build();

--- a/metric-schema-java/src/test/resources/namespace-tags.yml
+++ b/metric-schema-java/src/test/resources/namespace-tags.yml
@@ -24,3 +24,6 @@ namespaces:
         tags:
           - name: otherLocator2
             values: [ package:identifier ]
+      gauges:
+        type: gauge
+        docs: Gauges something

--- a/metric-schema-java/src/test/resources/namespace-tags.yml
+++ b/metric-schema-java/src/test/resources/namespace-tags.yml
@@ -19,11 +19,17 @@ namespaces:
           - name: otherLocator
             values: [ package:identifier, package:identifier2 ]
       more:
-        docs: Measures more
-        type: meter
+        docs: Counts something
+        type: counter
         tags:
           - name: otherLocator2
             values: [ package:identifier ]
       gauges:
         type: gauge
         docs: Gauges something
+      times:
+        type: timer
+        docs: Times something
+      histograms:
+        type: histogram
+        docs: Histograms something


### PR DESCRIPTION
## Before this PR

https://github.com/palantir/metric-schema/pull/840 introduced namespace tags, but missed a case of gauges.

## After this PR
==COMMIT_MSG==
Fix gauges when namespace tags are applied.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->