### PR TITLE
Fix deprecated Gradle API usage

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
@@ -22,6 +22,7 @@ import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.markdown.MarkdownRenderer;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import org.gradle.api.DefaultTask;
@@ -37,7 +38,6 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.util.GFileUtils;
 
 @CacheableTask
 public class CheckMetricMarkdownTask extends DefaultTask {
@@ -91,7 +91,7 @@ public class CheckMetricMarkdownTask extends DefaultTask {
                             + "`./gradlew --write-locks` and commit the resultant file",
                     markdown.getName(), getName()));
         } else {
-            String fromDisk = GFileUtils.readFile(markdown);
+            String fromDisk = Files.readString(markdown.toPath().toAbsolutePath());
             Preconditions.checkState(
                     fromDisk.equals(upToDateContents),
                     "%s is out of date, please run `./gradlew %s` or `./gradlew --write-locks` to update it.",

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
@@ -21,6 +21,7 @@ import com.palantir.metric.schema.MetricSchema;
 import com.palantir.metric.schema.markdown.MarkdownRenderer;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import org.gradle.api.DefaultTask;
@@ -36,7 +37,6 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.util.GFileUtils;
 
 @CacheableTask
 public class GenerateMetricMarkdownTask extends DefaultTask {
@@ -87,7 +87,7 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
         }
 
         String upToDateContents = MarkdownRenderer.render(localCoordinates.get(), schemas);
-        GFileUtils.writeFile(upToDateContents, markdown);
+        Files.writeString(markdown.toPath(), upToDateContents);
     }
 
     private static boolean isEmpty(Map<String, List<MetricSchema>> schemas) {


### PR DESCRIPTION
## Before this PR
Gradle excavator #888 [failing due to deprecated GFileUtils usage](https://app.circleci.com/jobs/github/palantir/metric-schema/11847)

## After this PR
==COMMIT_MSG==
Fix deprecated Gradle API usage
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->