### PR TITLE
Generate metric name methods for all metrics

### DIFF
--- a/changelog/@unreleased/pr-1007.v2.yml
+++ b/changelog/@unreleased/pr-1007.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Generate metric name methods for all metrics.
+  links:
+  - https://github.com/palantir/metric-schema/pull/1007

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -42,14 +42,18 @@ public final class MonitorsMetrics {
      */
     @CheckReturnValue
     public Meter more(@Safe String type) {
-        return registry.meter(MetricName.builder()
+        return registry.meter(moreMetricName(type));
+    }
+
+    public static MetricName moreMetricName(@Safe String type) {
+        return MetricName.builder()
                 .safeName("monitors.more")
                 .putSafeTags("type", type)
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
-                .build());
+                .build();
     }
 
     @Override
@@ -92,6 +96,8 @@ public final class MonitorsMetrics {
     public interface ProcessingBuildStage {
         @CheckReturnValue
         Meter build();
+
+        MetricName buildMetricName();
     }
 
     public interface ProcessingBuilderResultStage {
@@ -124,20 +130,6 @@ public final class MonitorsMetrics {
         private Processing_OtherLocator otherLocator;
 
         @Override
-        public Meter build() {
-            return registry.meter(MetricName.builder()
-                    .safeName("monitors.processing")
-                    .putSafeTags("result", result.getValue())
-                    .putSafeTags("type", type)
-                    .putSafeTags("locator", "package:identifier")
-                    .putSafeTags("otherLocator", otherLocator.getValue())
-                    .putSafeTags("libraryName", LIBRARY_NAME)
-                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                    .putSafeTags("javaVersion", JAVA_VERSION)
-                    .build());
-        }
-
-        @Override
         public ProcessingBuilder result(@Safe Processing_Result result) {
             Preconditions.checkState(this.result == null, "result is already set");
             this.result = Preconditions.checkNotNull(result, "result is required");
@@ -156,6 +148,25 @@ public final class MonitorsMetrics {
             Preconditions.checkState(this.otherLocator == null, "otherLocator is already set");
             this.otherLocator = Preconditions.checkNotNull(otherLocator, "otherLocator is required");
             return this;
+        }
+
+        @Override
+        public Meter build() {
+            return registry.meter(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("monitors.processing")
+                    .putSafeTags("result", result.getValue())
+                    .putSafeTags("type", type)
+                    .putSafeTags("locator", "package:identifier")
+                    .putSafeTags("otherLocator", otherLocator.getValue())
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
+                    .build();
         }
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -97,6 +97,7 @@ public final class MonitorsMetrics {
         @CheckReturnValue
         Meter build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -62,6 +62,8 @@ public final class MyNamespaceMetrics {
     public interface ResponseSizeBuildStage {
         @CheckReturnValue
         Histogram build();
+
+        MetricName buildMetricName();
     }
 
     public interface ResponseSizeBuilderServiceNameStage {
@@ -81,18 +83,6 @@ public final class MyNamespaceMetrics {
         private String endpoint;
 
         @Override
-        public Histogram build() {
-            return registry.histogram(MetricName.builder()
-                    .safeName("com.palantir.very.long.namespace.response.size")
-                    .putSafeTags("service-name", serviceName)
-                    .putSafeTags("endpoint", endpoint)
-                    .putSafeTags("libraryName", LIBRARY_NAME)
-                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                    .putSafeTags("javaVersion", JAVA_VERSION)
-                    .build());
-        }
-
-        @Override
         public ResponseSizeBuilder serviceName(@Safe String serviceName) {
             Preconditions.checkState(this.serviceName == null, "service-name is already set");
             this.serviceName = Preconditions.checkNotNull(serviceName, "service-name is required");
@@ -104,6 +94,23 @@ public final class MyNamespaceMetrics {
             Preconditions.checkState(this.endpoint == null, "endpoint is already set");
             this.endpoint = Preconditions.checkNotNull(endpoint, "endpoint is required");
             return this;
+        }
+
+        @Override
+        public Histogram build() {
+            return registry.histogram(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("com.palantir.very.long.namespace.response.size")
+                    .putSafeTags("service-name", serviceName)
+                    .putSafeTags("endpoint", endpoint)
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
+                    .build();
         }
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -63,6 +63,7 @@ public final class MyNamespaceMetrics {
         @CheckReturnValue
         Histogram build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -56,7 +56,11 @@ public final class NamespaceTagsMetrics {
      */
     @CheckReturnValue
     public Counter more() {
-        return registry.counter(MetricName.builder()
+        return registry.counter(moreMetricName());
+    }
+
+    public MetricName moreMetricName() {
+        return MetricName.builder()
                 .safeName("namespace-tags.more")
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("noValueTag", noValueTag)
@@ -65,7 +69,7 @@ public final class NamespaceTagsMetrics {
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
-                .build());
+                .build();
     }
 
     /**
@@ -92,7 +96,11 @@ public final class NamespaceTagsMetrics {
      */
     @CheckReturnValue
     public Timer times() {
-        return registry.timer(MetricName.builder()
+        return registry.timer(timesMetricName());
+    }
+
+    public MetricName timesMetricName() {
+        return MetricName.builder()
                 .safeName("namespace-tags.times")
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("noValueTag", noValueTag)
@@ -100,7 +108,7 @@ public final class NamespaceTagsMetrics {
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
-                .build());
+                .build();
     }
 
     /**
@@ -108,7 +116,11 @@ public final class NamespaceTagsMetrics {
      */
     @CheckReturnValue
     public Histogram histograms() {
-        return registry.histogram(MetricName.builder()
+        return registry.histogram(histogramsMetricName());
+    }
+
+    public MetricName histogramsMetricName() {
+        return MetricName.builder()
                 .safeName("namespace-tags.histograms")
                 .putSafeTags("locator", "package:identifier")
                 .putSafeTags("noValueTag", noValueTag)
@@ -116,7 +128,7 @@ public final class NamespaceTagsMetrics {
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
-                .build());
+                .build();
     }
 
     @Override
@@ -238,6 +250,8 @@ public final class NamespaceTagsMetrics {
     public interface ProcessingBuildStage {
         @CheckReturnValue
         Meter build();
+
+        MetricName buildMetricName();
     }
 
     public interface ProcessingBuilderResultStage {
@@ -270,22 +284,6 @@ public final class NamespaceTagsMetrics {
         private Processing_OtherLocator otherLocator;
 
         @Override
-        public Meter build() {
-            return registry.meter(MetricName.builder()
-                    .safeName("namespace-tags.processing")
-                    .putSafeTags("locator", "package:identifier")
-                    .putSafeTags("noValueTag", noValueTag)
-                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
-                    .putSafeTags("result", result.getValue())
-                    .putSafeTags("type", type)
-                    .putSafeTags("otherLocator", otherLocator.getValue())
-                    .putSafeTags("libraryName", LIBRARY_NAME)
-                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                    .putSafeTags("javaVersion", JAVA_VERSION)
-                    .build());
-        }
-
-        @Override
         public ProcessingBuilder result(@Safe Processing_Result result) {
             Preconditions.checkState(this.result == null, "result is already set");
             this.result = Preconditions.checkNotNull(result, "result is required");
@@ -304,6 +302,27 @@ public final class NamespaceTagsMetrics {
             Preconditions.checkState(this.otherLocator == null, "otherLocator is already set");
             this.otherLocator = Preconditions.checkNotNull(otherLocator, "otherLocator is required");
             return this;
+        }
+
+        @Override
+        public Meter build() {
+            return registry.meter(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("namespace-tags.processing")
+                    .putSafeTags("locator", "package:identifier")
+                    .putSafeTags("noValueTag", noValueTag)
+                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
+                    .putSafeTags("result", result.getValue())
+                    .putSafeTags("type", type)
+                    .putSafeTags("otherLocator", otherLocator.getValue())
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
+                    .build();
         }
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -251,6 +251,7 @@ public final class NamespaceTagsMetrics {
         @CheckReturnValue
         Meter build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -106,6 +106,7 @@ public final class ReservedConflictMetrics {
         @CheckReturnValue
         Histogram build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 
@@ -175,6 +176,7 @@ public final class ReservedConflictMetrics {
     public interface DoubleBuildStage {
         void build(Gauge<?> gauge);
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 
@@ -214,6 +216,7 @@ public final class ReservedConflictMetrics {
         @CheckReturnValue
         Meter build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 
@@ -284,6 +287,7 @@ public final class ReservedConflictMetrics {
         @CheckReturnValue
         Meter build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -44,13 +44,17 @@ public final class ReservedConflictMetrics {
      */
     @CheckReturnValue
     public Meter long_(@Safe String int_) {
-        return registry.meter(MetricName.builder()
+        return registry.meter(longMetricName(int_));
+    }
+
+    public static MetricName longMetricName(@Safe String int_) {
+        return MetricName.builder()
                 .safeName("reserved.conflict.long")
                 .putSafeTags("int", int_)
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
-                .build());
+                .build();
     }
 
     /**
@@ -101,6 +105,8 @@ public final class ReservedConflictMetrics {
     public interface IntBuildStage {
         @CheckReturnValue
         Histogram build();
+
+        MetricName buildMetricName();
     }
 
     public interface IntBuilderIntStage {
@@ -127,19 +133,6 @@ public final class ReservedConflictMetrics {
         private String long_;
 
         @Override
-        public Histogram build() {
-            return registry.histogram(MetricName.builder()
-                    .safeName("reserved.conflict.int")
-                    .putSafeTags("int", int_)
-                    .putSafeTags("registry", registry_)
-                    .putSafeTags("long", long_)
-                    .putSafeTags("libraryName", LIBRARY_NAME)
-                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                    .putSafeTags("javaVersion", JAVA_VERSION)
-                    .build());
-        }
-
-        @Override
         public IntBuilder int_(@Safe String int_) {
             Preconditions.checkState(this.int_ == null, "int is already set");
             this.int_ = Preconditions.checkNotNull(int_, "int is required");
@@ -159,6 +152,24 @@ public final class ReservedConflictMetrics {
             this.long_ = Preconditions.checkNotNull(long_, "long is required");
             return this;
         }
+
+        @Override
+        public Histogram build() {
+            return registry.histogram(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("reserved.conflict.int")
+                    .putSafeTags("int", int_)
+                    .putSafeTags("registry", registry_)
+                    .putSafeTags("long", long_)
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
+                    .build();
+        }
     }
 
     public interface DoubleBuildStage {
@@ -176,6 +187,13 @@ public final class ReservedConflictMetrics {
         private String int_;
 
         @Override
+        public DoubleBuilder int_(@Safe String int_) {
+            Preconditions.checkState(this.int_ == null, "int is already set");
+            this.int_ = Preconditions.checkNotNull(int_, "int is required");
+            return this;
+        }
+
+        @Override
         public void build(Gauge<?> gauge) {
             registry.registerWithReplacement(buildMetricName(), gauge);
         }
@@ -190,18 +208,13 @@ public final class ReservedConflictMetrics {
                     .putSafeTags("javaVersion", JAVA_VERSION)
                     .build();
         }
-
-        @Override
-        public DoubleBuilder int_(@Safe String int_) {
-            Preconditions.checkState(this.int_ == null, "int is already set");
-            this.int_ = Preconditions.checkNotNull(int_, "int is required");
-            return this;
-        }
     }
 
     public interface IncludesDefaultTagsBuildStage {
         @CheckReturnValue
         Meter build();
+
+        MetricName buildMetricName();
     }
 
     public interface IncludesDefaultTagsBuilderJavaVersionStage {
@@ -231,16 +244,6 @@ public final class ReservedConflictMetrics {
         private String libraryVersion;
 
         @Override
-        public Meter build() {
-            return registry.meter(MetricName.builder()
-                    .safeName("reserved.conflict.includes.default.tags")
-                    .putSafeTags("javaVersion", javaVersion)
-                    .putSafeTags("libraryName", libraryName)
-                    .putSafeTags("libraryVersion", libraryVersion)
-                    .build());
-        }
-
-        @Override
         public IncludesDefaultTagsBuilder javaVersion(@Safe String javaVersion) {
             Preconditions.checkState(this.javaVersion == null, "javaVersion is already set");
             this.javaVersion = Preconditions.checkNotNull(javaVersion, "javaVersion is required");
@@ -260,11 +263,28 @@ public final class ReservedConflictMetrics {
             this.libraryVersion = Preconditions.checkNotNull(libraryVersion, "libraryVersion is required");
             return this;
         }
+
+        @Override
+        public Meter build() {
+            return registry.meter(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("reserved.conflict.includes.default.tags")
+                    .putSafeTags("javaVersion", javaVersion)
+                    .putSafeTags("libraryName", libraryName)
+                    .putSafeTags("libraryVersion", libraryVersion)
+                    .build();
+        }
     }
 
     public interface IncludesDefaultTagsDifferentCaseBuildStage {
         @CheckReturnValue
         Meter build();
+
+        MetricName buildMetricName();
     }
 
     public interface IncludesDefaultTagsDifferentCaseBuilderJavaversionStage {
@@ -294,16 +314,6 @@ public final class ReservedConflictMetrics {
         private String libraryversion;
 
         @Override
-        public Meter build() {
-            return registry.meter(MetricName.builder()
-                    .safeName("reserved.conflict.includes.default.tags.different.case")
-                    .putSafeTags("javaversion", javaversion)
-                    .putSafeTags("libraryname", libraryname)
-                    .putSafeTags("libraryversion", libraryversion)
-                    .build());
-        }
-
-        @Override
         public IncludesDefaultTagsDifferentCaseBuilder javaversion(@Safe String javaversion) {
             Preconditions.checkState(this.javaversion == null, "javaversion is already set");
             this.javaversion = Preconditions.checkNotNull(javaversion, "javaversion is required");
@@ -322,6 +332,21 @@ public final class ReservedConflictMetrics {
             Preconditions.checkState(this.libraryversion == null, "libraryversion is already set");
             this.libraryversion = Preconditions.checkNotNull(libraryversion, "libraryversion is required");
             return this;
+        }
+
+        @Override
+        public Meter build() {
+            return registry.meter(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("reserved.conflict.includes.default.tags.different.case")
+                    .putSafeTags("javaversion", javaversion)
+                    .putSafeTags("libraryname", libraryname)
+                    .putSafeTags("libraryversion", libraryversion)
+                    .build();
         }
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -63,6 +63,7 @@ public final class ServerMetrics {
         @CheckReturnValue
         Histogram build();
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -62,6 +62,8 @@ public final class ServerMetrics {
     public interface ResponseSizeBuildStage {
         @CheckReturnValue
         Histogram build();
+
+        MetricName buildMetricName();
     }
 
     public interface ResponseSizeBuilderServiceNameStage {
@@ -81,18 +83,6 @@ public final class ServerMetrics {
         private String endpoint;
 
         @Override
-        public Histogram build() {
-            return registry.histogram(MetricName.builder()
-                    .safeName("server.response.size")
-                    .putSafeTags("service-name", serviceName)
-                    .putSafeTags("endpoint", endpoint)
-                    .putSafeTags("libraryName", LIBRARY_NAME)
-                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                    .putSafeTags("javaVersion", JAVA_VERSION)
-                    .build());
-        }
-
-        @Override
         public ResponseSizeBuilder serviceName(@Safe String serviceName) {
             Preconditions.checkState(this.serviceName == null, "service-name is already set");
             this.serviceName = Preconditions.checkNotNull(serviceName, "service-name is required");
@@ -104,6 +94,23 @@ public final class ServerMetrics {
             Preconditions.checkState(this.endpoint == null, "endpoint is already set");
             this.endpoint = Preconditions.checkNotNull(endpoint, "endpoint is required");
             return this;
+        }
+
+        @Override
+        public Histogram build() {
+            return registry.histogram(buildMetricName());
+        }
+
+        @Override
+        public MetricName buildMetricName() {
+            return MetricName.builder()
+                    .safeName("server.response.size")
+                    .putSafeTags("service-name", serviceName)
+                    .putSafeTags("endpoint", endpoint)
+                    .putSafeTags("libraryName", LIBRARY_NAME)
+                    .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                    .putSafeTags("javaVersion", JAVA_VERSION)
+                    .build();
         }
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -35,12 +35,16 @@ final class VisibilityMetrics {
      */
     @CheckReturnValue
     Counter test() {
-        return registry.counter(MetricName.builder()
+        return registry.counter(testMetricName());
+    }
+
+    static MetricName testMetricName() {
+        return MetricName.builder()
                 .safeName("visibility.test")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
                 .putSafeTags("javaVersion", JAVA_VERSION)
-                .build());
+                .build();
     }
 
     /**
@@ -78,6 +82,20 @@ final class VisibilityMetrics {
         private String bar;
 
         @Override
+        public ComplexBuilder foo(@Safe String foo) {
+            Preconditions.checkState(this.foo == null, "foo is already set");
+            this.foo = Preconditions.checkNotNull(foo, "foo is required");
+            return this;
+        }
+
+        @Override
+        public ComplexBuilder bar(@Safe String bar) {
+            Preconditions.checkState(this.bar == null, "bar is already set");
+            this.bar = Preconditions.checkNotNull(bar, "bar is required");
+            return this;
+        }
+
+        @Override
         public void build(Gauge<?> gauge) {
             registry.registerWithReplacement(buildMetricName(), gauge);
         }
@@ -92,20 +110,6 @@ final class VisibilityMetrics {
                     .putSafeTags("libraryVersion", LIBRARY_VERSION)
                     .putSafeTags("javaVersion", JAVA_VERSION)
                     .build();
-        }
-
-        @Override
-        public ComplexBuilder foo(@Safe String foo) {
-            Preconditions.checkState(this.foo == null, "foo is already set");
-            this.foo = Preconditions.checkNotNull(foo, "foo is required");
-            return this;
-        }
-
-        @Override
-        public ComplexBuilder bar(@Safe String bar) {
-            Preconditions.checkState(this.bar == null, "bar is already set");
-            this.bar = Preconditions.checkNotNull(bar, "bar is required");
-            return this;
         }
     }
 }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -63,6 +63,7 @@ final class VisibilityMetrics {
     interface ComplexBuildStage {
         void build(Gauge<?> gauge);
 
+        @CheckReturnValue
         MetricName buildMetricName();
     }
 

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -517,6 +517,7 @@ final class UtilityGenerator {
         MethodSpec abstractBuildMethod = abstractBuildMethodBuilder.build();
         MethodSpec abstractBuildMetricName = MethodSpec.methodBuilder("buildMetricName")
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addAnnotation(CheckReturnValue.class)
                 .returns(MetricName.class)
                 .build();
 


### PR DESCRIPTION
Continuation of https://github.com/palantir/metric-schema/pull/293, but exposing this capability for all metrics.

I think the risk of misuse is minimal. Consumers can always bypass metric-schema entirely if they want. But if they want/need to off-road, it's better to at least have the metrics documented in metric-schema.

There are a couple places in our internal server library where this would be useful.