### PR TITLE
Allow optional documentations for tag enumerations

### DIFF
--- a/metric-schema-api/src/main/conjure/metric-schema-api.yml
+++ b/metric-schema-api/src/main/conjure/metric-schema-api.yml
@@ -44,3 +44,4 @@ types:
       TagValue:
         fields:
           value: string
+          docs: optional<Documentation>

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -62,6 +62,9 @@ public final class MonitorsMetrics {
     }
 
     public enum Processing_Result {
+        /**
+         * Successful installations processed
+         */
         SUCCESS("success"),
 
         FAILURE("failure");

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -315,10 +315,11 @@ final class UtilityGenerator {
     private static void generateTagEnum(
             TypeSpec.Builder builder, String metricName, ImplementationVisibility visibility, TagDefinition tagDef) {
         TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(getTagClassName(metricName, tagDef));
-        tagDef.getValues()
-                .forEach(value -> enumBuilder.addEnumConstant(
-                        Custodian.anyToUpperUnderscore(value.getValue()),
-                        TypeSpec.anonymousClassBuilder("$S", value.getValue()).build()));
+        tagDef.getValues().forEach(value -> {
+            TypeSpec.Builder tagValueBuilder = TypeSpec.anonymousClassBuilder("$S", value.getValue());
+            value.getDocs().map(Javadoc::render).ifPresent(tagValueBuilder::addJavadoc);
+            enumBuilder.addEnumConstant(Custodian.anyToUpperUnderscore(value.getValue()), tagValueBuilder.build());
+        });
 
         builder.addType(enumBuilder
                 .addModifiers(visibility.apply())

--- a/metric-schema-java/src/test/resources/constant-tags.yml
+++ b/metric-schema-java/src/test/resources/constant-tags.yml
@@ -8,7 +8,10 @@ namespaces:
         tags:
           - name: result
             docs: The result of processing
-            values: [success, failure]
+            values:
+              - value: success
+                docs: Successful installations processed
+              - failure
           - type
           - name: locator
             values: [ package:identifier ]

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/LangConverter.java
@@ -56,9 +56,18 @@ final class LangConverter {
                 .map(tag -> TagDefinition.builder()
                         .name(tag.name())
                         .docs(tag.docs().map(Documentation::of))
-                        .values(tag.values().stream().map(TagValue::of).collect(ImmutableList.toImmutableList()))
+                        .values(tag.values().stream()
+                                .map(LangConverter::convert)
+                                .collect(ImmutableList.toImmutableList()))
                         .build())
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    private static TagValue convert(com.palantir.metric.schema.lang.TagValue tagValue) {
+        return TagValue.builder()
+                .value(tagValue.value())
+                .docs(tagValue.docs().map(Documentation::of))
+                .build();
     }
 
     private LangConverter() {}

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagValue.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagValue.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,27 +22,24 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
-@JsonDeserialize(using = TagDefinition.TagDefinitionDeserializer.class)
-public interface TagDefinition {
-    String name();
+@JsonDeserialize(using = TagValue.TagValueDeserializer.class)
+public interface TagValue {
+    String value();
 
     Optional<String> docs();
 
-    List<TagValue> values();
-
-    final class TagDefinitionDeserializer extends JsonDeserializer<TagDefinition> {
+    final class TagValueDeserializer extends JsonDeserializer<TagValue> {
         @Override
-        public TagDefinition deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
+        public TagValue deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
             if (parser.currentToken() == JsonToken.VALUE_STRING) {
-                String name = parser.getValueAsString();
-                return ImmutableTagDefinition.builder().name(name).build();
+                String value = parser.getValueAsString();
+                return ImmutableTagValue.builder().value(value).build();
             }
-            return ImmutableTagDefinition.fromJson(parser.readValueAs(ImmutableTagDefinition.Json.class));
+            return ImmutableTagValue.fromJson(parser.readValueAs(ImmutableTagValue.Json.class));
         }
     }
 }

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -121,7 +121,6 @@ public final class MarkdownRenderer {
                 output.append(" values ")
                         .append(tagDefinition.getValues().stream()
                                 .map(TagValue::getValue)
-                                .sorted()
                                 .collect(Collectors.joining("`,`", "(`", "`)")));
             }
 
@@ -131,13 +130,11 @@ public final class MarkdownRenderer {
             output.append("\n");
 
             if (hasEnumValueDocs) {
-                tagDefinition.getValues().stream()
-                        .sorted(Comparator.comparing(TagValue::getValue))
-                        .forEach(value -> {
-                            output.append(String.format("    - `%s`", value.getValue()));
-                            value.getDocs().ifPresent(docs -> output.append(String.format(": %s", docs)));
-                            output.append("\n");
-                        });
+                tagDefinition.getValues().forEach(value -> {
+                    output.append(String.format("    - `%s`", value.getValue()));
+                    value.getDocs().ifPresent(docs -> output.append(String.format(": %s", docs)));
+                    output.append("\n");
+                });
             }
         });
     }

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
@@ -106,28 +107,39 @@ public final class MarkdownRenderer {
                 .append(metric.getDocs().get())
                 .append('\n');
         if (hasComplexTags) {
-            allTags.forEach(tagDefinition -> {
-                output.append("  - `").append(tagDefinition.getName()).append("`");
-                if (!tagDefinition.getValues().isEmpty()) {
-                    output.append(" values ")
-                            .append(tagDefinition.getValues().stream()
-                                    .map(TagValue::getValue)
-                                    .sorted()
-                                    .collect(Collectors.joining("`,`", "(`", "`)")));
-                }
-                tagDefinition.getDocs().ifPresent(docs -> {
-                    output.append(": ").append(docs);
-                });
-                output.append("\n");
-
-                tagDefinition.getValues().forEach(value -> {
-                    value.getDocs()
-                            .ifPresent(_doc -> output.append(String.format(
-                                    "    - `%s`: %s\n",
-                                    value.getValue(), value.getDocs().get())));
-                });
-            });
+            renderComplexTags(allTags, output);
         }
+    }
+
+    private static void renderComplexTags(List<TagDefinition> tagDefinitions, StringBuilder output) {
+        tagDefinitions.forEach(tagDefinition -> {
+            boolean hasEnumValueDocs =
+                    tagDefinition.getValues().stream().map(TagValue::getDocs).anyMatch(Optional::isPresent);
+
+            output.append("  - `").append(tagDefinition.getName()).append("`");
+            if (!tagDefinition.getValues().isEmpty() && !hasEnumValueDocs) {
+                output.append(" values ")
+                        .append(tagDefinition.getValues().stream()
+                                .map(TagValue::getValue)
+                                .sorted()
+                                .collect(Collectors.joining("`,`", "(`", "`)")));
+            }
+
+            tagDefinition.getDocs().ifPresent(docs -> {
+                output.append(": ").append(docs);
+            });
+            output.append("\n");
+
+            if (hasEnumValueDocs) {
+                tagDefinition.getValues().stream()
+                        .sorted(Comparator.comparing(TagValue::getValue))
+                        .forEach(value -> {
+                            output.append(String.format("    - `%s`", value.getValue()));
+                            value.getDocs().ifPresent(docs -> output.append(String.format(": %s", docs)));
+                            output.append("\n");
+                        });
+            }
+        });
     }
 
     private static ImmutableList<Section> namespaces(String localCoordinate, Map<String, List<MetricSchema>> schemas) {

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -119,6 +119,13 @@ public final class MarkdownRenderer {
                     output.append(": ").append(docs);
                 });
                 output.append("\n");
+
+                tagDefinition.getValues().forEach(value -> {
+                    value.getDocs()
+                            .ifPresent(_doc -> output.append(String.format(
+                                    "    - `%s`: %s\n",
+                                    value.getValue(), value.getDocs().get())));
+                });
             });
         }
     }

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -213,6 +213,15 @@ class MarkdownRendererTest {
                                                         .name("endpoint")
                                                         .docs(Documentation.of("Some docs"))
                                                         .build())
+                                                .tagDefinitions(TagDefinition.builder()
+                                                        .name("processing")
+                                                        .values(TagValue.builder()
+                                                                .value("foo")
+                                                                .build())
+                                                        .values(TagValue.builder()
+                                                                .value("bar")
+                                                                .build())
+                                                        .build())
                                                 .docs(Documentation.of("metric docs"))
                                                 .build())
                                 .build())
@@ -230,9 +239,11 @@ class MarkdownRendererTest {
                         + "namespace docs\n"
                         + "- `namespace.metric` (meter): metric docs\n"
                         + "  - `namespaceTag`\n"
-                        + "  - `result` values (`failure`,`success`)\n"
+                        + "  - `result`\n"
+                        + "    - `failure`\n"
                         + "    - `success`: This is a success enum\n"
-                        + "  - `endpoint`: Some docs");
+                        + "  - `endpoint`: Some docs\n"
+                        + "  - `processing` values (`bar`,`foo`)");
     }
 
     @Test

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -240,10 +240,10 @@ class MarkdownRendererTest {
                         + "- `namespace.metric` (meter): metric docs\n"
                         + "  - `namespaceTag`\n"
                         + "  - `result`\n"
-                        + "    - `failure`\n"
                         + "    - `success`: This is a success enum\n"
+                        + "    - `failure`\n"
                         + "  - `endpoint`: Some docs\n"
-                        + "  - `processing` values (`bar`,`foo`)");
+                        + "  - `processing` values (`foo`,`bar`)");
     }
 
     @Test

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -203,8 +203,11 @@ class MarkdownRendererTest {
                                                 .type(MetricType.METER)
                                                 .tagDefinitions(TagDefinition.builder()
                                                         .name("result")
-                                                        .values(TagValue.of("success"))
-                                                        .values(TagValue.of("failure"))
+                                                        .values(TagValue.of(
+                                                                "success", Documentation.of("This is a success enum")))
+                                                        .values(TagValue.builder()
+                                                                .value("failure")
+                                                                .build())
                                                         .build())
                                                 .tagDefinitions(TagDefinition.builder()
                                                         .name("endpoint")
@@ -228,6 +231,7 @@ class MarkdownRendererTest {
                         + "- `namespace.metric` (meter): metric docs\n"
                         + "  - `namespaceTag`\n"
                         + "  - `result` values (`failure`,`success`)\n"
+                        + "    - `success`: This is a success enum\n"
                         + "  - `endpoint`: Some docs");
     }
 


### PR DESCRIPTION
The changes to this commit addresses issue #1016.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Some tag value enumerations require additional documentations to understand their purposes. The workaround so far is to add documentations for tag values in the `docs` field for `TagDefinition`. While this work, it feels clunky and does not work great when developers want to find out what individual enums represent.

## After this PR

Users can now optionally define documentation for individual tag value enumerations. If a tag value enumerations contain multiple values, individual `TagValue` with `docs` defined field will have their documentation rendered in Markdown and generated Java code. The changes are compatible for existing clients.

==COMMIT_MSG==
Allow optional documentations for tag enumerations
==COMMIT_MSG==

## Are Docs needed?

We decided to remove sorting `TagValue` enumeration in the output Markdown, which will cause diff logs for `metrics.md`.