### PR TITLE
Have metric-schema accept numeric Gauges only

### DIFF
--- a/changelog/@unreleased/pr-1040.v2.yml
+++ b/changelog/@unreleased/pr-1040.v2.yml
@@ -1,0 +1,8 @@
+type: break
+break:
+  description: |-
+    <!-- User-facing outcomes this PR delivers -->
+    Gauges now require numeric return types. This matches the constraints of Prometheus
+    and avoids having non-numeric values silently dropped downstream.
+  links:
+  - https://github.com/palantir/metric-schema/pull/1040

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -41,7 +41,7 @@ public final class MyNamespaceMetrics {
     /**
      * A gauge of the ratio of active workers to the number of workers.
      */
-    public void workerUtilization(Gauge<?> gauge) {
+    public void workerUtilization(Gauge<? extends Number> gauge) {
         registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -75,7 +75,7 @@ public final class NamespaceTagsMetrics {
     /**
      * Gauges something
      */
-    public void gauges(Gauge<?> gauge) {
+    public void gauges(Gauge<? extends Number> gauge) {
         registry.registerWithReplacement(gaugesMetricName(), gauge);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -60,7 +60,7 @@ public final class ReservedConflictMetrics {
     /**
      * Gauge metric with a single no tags.
      */
-    public void float_(Gauge<?> gauge) {
+    public void float_(Gauge<? extends Number> gauge) {
         registry.registerWithReplacement(floatMetricName(), gauge);
     }
 
@@ -174,7 +174,7 @@ public final class ReservedConflictMetrics {
     }
 
     public interface DoubleBuildStage {
-        void build(Gauge<?> gauge);
+        void build(Gauge<? extends Number> gauge);
 
         @CheckReturnValue
         MetricName buildMetricName();
@@ -196,7 +196,7 @@ public final class ReservedConflictMetrics {
         }
 
         @Override
-        public void build(Gauge<?> gauge) {
+        public void build(Gauge<? extends Number> gauge) {
             registry.registerWithReplacement(buildMetricName(), gauge);
         }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -41,7 +41,7 @@ public final class ServerMetrics {
     /**
      * A gauge of the ratio of active workers to the number of workers.
      */
-    public void workerUtilization(Gauge<?> gauge) {
+    public void workerUtilization(Gauge<? extends Number> gauge) {
         registry.registerWithReplacement(workerUtilizationMetricName(), gauge);
     }
 

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -61,7 +61,7 @@ final class VisibilityMetrics {
     }
 
     interface ComplexBuildStage {
-        void build(Gauge<?> gauge);
+        void build(Gauge<? extends Number> gauge);
 
         @CheckReturnValue
         MetricName buildMetricName();
@@ -97,7 +97,7 @@ final class VisibilityMetrics {
         }
 
         @Override
-        public void build(Gauge<?> gauge) {
+        public void build(Gauge<? extends Number> gauge) {
             registry.registerWithReplacement(buildMetricName(), gauge);
         }
 

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -471,7 +471,7 @@ final class UtilityGenerator {
                         ","));
         if (isGauge) {
             methodBuilder.addParameter(
-                    ParameterizedTypeName.get(ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Object.class)),
+                    ParameterizedTypeName.get(ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Number.class)),
                     ReservedNames.GAUGE_NAME);
             // TODO(ckozak): Update to use a method which can log a warning and replace existing gauges.
             // See MetricRegistries.registerWithReplacement.
@@ -510,7 +510,7 @@ final class UtilityGenerator {
                 .returns(MetricTypes.type(definition.getType()));
         if (isGauge) {
             abstractBuildMethodBuilder.addParameter(
-                    ParameterizedTypeName.get(ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Object.class)),
+                    ParameterizedTypeName.get(ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Number.class)),
                     ReservedNames.GAUGE_NAME);
         } else {
             abstractBuildMethodBuilder.addAnnotation(CheckReturnValue.class);
@@ -571,7 +571,7 @@ final class UtilityGenerator {
             buildMethodBuilder
                     .addParameter(
                             ParameterizedTypeName.get(
-                                    ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Object.class)),
+                                    ClassName.get(Gauge.class), WildcardTypeName.subtypeOf(Number.class)),
                             ReservedNames.GAUGE_NAME)
                     // TODO(ckozak): Update to use a method which can log a warning and replace existing gauges.
                     // See MetricRegistries.registerWithReplacement.


### PR DESCRIPTION
Gauges only work properly with Prometheus if they are numeric-typed, i.e. convertible to float64. To enforce this in Java, replace Gauge<?> with Gauge<? extends Number>.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Gauge declarations are untyped, allowing for any value type even though only numbers are legal.

## After this PR
==COMMIT_MSG==
Gauges will only accept numeric types, matching the constraints of Prometheus (thus ensuring the Gauge
won't be silently dropped downstream).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Library consumers may need to fix bugs where gauges are returning
non-numeric types.