### PR TITLE
Cache metric names when possible

### DIFF
--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -20,6 +20,13 @@ public final class MyNamespaceMetrics {
     private static final String LIBRARY_VERSION =
             Objects.requireNonNullElse(MyNamespaceMetrics.class.getPackage().getImplementationVersion(), "unknown");
 
+    private static final MetricName workerUtilizationMetricName = MetricName.builder()
+            .safeName("com.palantir.very.long.namespace.worker.utilization")
+            .putSafeTags("libraryName", LIBRARY_NAME)
+            .putSafeTags("libraryVersion", LIBRARY_VERSION)
+            .putSafeTags("javaVersion", JAVA_VERSION)
+            .build();
+
     private final TaggedMetricRegistry registry;
 
     private MyNamespaceMetrics(TaggedMetricRegistry registry) {
@@ -46,12 +53,7 @@ public final class MyNamespaceMetrics {
     }
 
     public static MetricName workerUtilizationMetricName() {
-        return MetricName.builder()
-                .safeName("com.palantir.very.long.namespace.worker.utilization")
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return workerUtilizationMetricName;
     }
 
     @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -25,17 +25,50 @@ public final class NamespaceTagsMetrics {
 
     private final TaggedMetricRegistry registry;
 
-    private final String noValueTag;
+    private final String noValueTagValue;
 
-    private final String locatorWithMultipleValues;
+    private final String locatorWithMultipleValuesValue;
+
+    private final MetricName gaugesMetricName;
+
+    private final MetricName timesMetricName;
+
+    private final MetricName histogramsMetricName;
 
     private NamespaceTagsMetrics(
             TaggedMetricRegistry registry,
             String noValueTag,
             NamespaceTags_LocatorWithMultipleValues locatorWithMultipleValues) {
         this.registry = registry;
-        this.noValueTag = noValueTag;
-        this.locatorWithMultipleValues = locatorWithMultipleValues.getValue();
+        this.noValueTagValue = noValueTag;
+        this.locatorWithMultipleValuesValue = locatorWithMultipleValues.getValue();
+        this.gaugesMetricName = MetricName.builder()
+                .safeName("namespace-tags.gauges")
+                .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTagValue)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValuesValue)
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build();
+        this.timesMetricName = MetricName.builder()
+                .safeName("namespace-tags.times")
+                .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTagValue)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValuesValue)
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build();
+        this.histogramsMetricName = MetricName.builder()
+                .safeName("namespace-tags.histograms")
+                .putSafeTags("locator", "package:identifier")
+                .putSafeTags("noValueTag", noValueTagValue)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValuesValue)
+                .putSafeTags("libraryName", LIBRARY_NAME)
+                .putSafeTags("libraryVersion", LIBRARY_VERSION)
+                .putSafeTags("javaVersion", JAVA_VERSION)
+                .build();
     }
 
     @CheckReturnValue
@@ -63,8 +96,8 @@ public final class NamespaceTagsMetrics {
         return MetricName.builder()
                 .safeName("namespace-tags.more")
                 .putSafeTags("locator", "package:identifier")
-                .putSafeTags("noValueTag", noValueTag)
-                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
+                .putSafeTags("noValueTag", noValueTagValue)
+                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValuesValue)
                 .putSafeTags("otherLocator2", "package:identifier")
                 .putSafeTags("libraryName", LIBRARY_NAME)
                 .putSafeTags("libraryVersion", LIBRARY_VERSION)
@@ -80,15 +113,7 @@ public final class NamespaceTagsMetrics {
     }
 
     public MetricName gaugesMetricName() {
-        return MetricName.builder()
-                .safeName("namespace-tags.gauges")
-                .putSafeTags("locator", "package:identifier")
-                .putSafeTags("noValueTag", noValueTag)
-                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return gaugesMetricName;
     }
 
     /**
@@ -100,15 +125,7 @@ public final class NamespaceTagsMetrics {
     }
 
     public MetricName timesMetricName() {
-        return MetricName.builder()
-                .safeName("namespace-tags.times")
-                .putSafeTags("locator", "package:identifier")
-                .putSafeTags("noValueTag", noValueTag)
-                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return timesMetricName;
     }
 
     /**
@@ -120,21 +137,13 @@ public final class NamespaceTagsMetrics {
     }
 
     public MetricName histogramsMetricName() {
-        return MetricName.builder()
-                .safeName("namespace-tags.histograms")
-                .putSafeTags("locator", "package:identifier")
-                .putSafeTags("noValueTag", noValueTag)
-                .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return histogramsMetricName;
     }
 
     @Override
     public String toString() {
         return "NamespaceTagsMetrics{registry=" + registry + ", locator=package:identifier" + ", noValueTag="
-                + noValueTag + ", locatorWithMultipleValues=" + locatorWithMultipleValues + '}';
+                + noValueTagValue + ", locatorWithMultipleValues=" + locatorWithMultipleValuesValue + '}';
     }
 
     public enum NamespaceTags_LocatorWithMultipleValues {
@@ -315,8 +324,8 @@ public final class NamespaceTagsMetrics {
             return MetricName.builder()
                     .safeName("namespace-tags.processing")
                     .putSafeTags("locator", "package:identifier")
-                    .putSafeTags("noValueTag", noValueTag)
-                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValues)
+                    .putSafeTags("noValueTag", noValueTagValue)
+                    .putSafeTags("locatorWithMultipleValues", locatorWithMultipleValuesValue)
                     .putSafeTags("result", result.getValue())
                     .putSafeTags("type", type)
                     .putSafeTags("otherLocator", otherLocator.getValue())

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -21,6 +21,13 @@ public final class ReservedConflictMetrics {
     private static final String LIBRARY_VERSION = Objects.requireNonNullElse(
             ReservedConflictMetrics.class.getPackage().getImplementationVersion(), "unknown");
 
+    private static final MetricName floatMetricName = MetricName.builder()
+            .safeName("reserved.conflict.float")
+            .putSafeTags("libraryName", LIBRARY_NAME)
+            .putSafeTags("libraryVersion", LIBRARY_VERSION)
+            .putSafeTags("javaVersion", JAVA_VERSION)
+            .build();
+
     private final TaggedMetricRegistry registry;
 
     private ReservedConflictMetrics(TaggedMetricRegistry registry) {
@@ -65,12 +72,7 @@ public final class ReservedConflictMetrics {
     }
 
     public static MetricName floatMetricName() {
-        return MetricName.builder()
-                .safeName("reserved.conflict.float")
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return floatMetricName;
     }
 
     /**

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -20,6 +20,13 @@ public final class ServerMetrics {
     private static final String LIBRARY_VERSION =
             Objects.requireNonNullElse(ServerMetrics.class.getPackage().getImplementationVersion(), "unknown");
 
+    private static final MetricName workerUtilizationMetricName = MetricName.builder()
+            .safeName("server.worker.utilization")
+            .putSafeTags("libraryName", LIBRARY_NAME)
+            .putSafeTags("libraryVersion", LIBRARY_VERSION)
+            .putSafeTags("javaVersion", JAVA_VERSION)
+            .build();
+
     private final TaggedMetricRegistry registry;
 
     private ServerMetrics(TaggedMetricRegistry registry) {
@@ -46,12 +53,7 @@ public final class ServerMetrics {
     }
 
     public static MetricName workerUtilizationMetricName() {
-        return MetricName.builder()
-                .safeName("server.worker.utilization")
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return workerUtilizationMetricName;
     }
 
     @Override

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -20,6 +20,13 @@ final class VisibilityMetrics {
     private static final String LIBRARY_VERSION =
             Objects.requireNonNullElse(VisibilityMetrics.class.getPackage().getImplementationVersion(), "unknown");
 
+    private static final MetricName testMetricName = MetricName.builder()
+            .safeName("visibility.test")
+            .putSafeTags("libraryName", LIBRARY_NAME)
+            .putSafeTags("libraryVersion", LIBRARY_VERSION)
+            .putSafeTags("javaVersion", JAVA_VERSION)
+            .build();
+
     private final TaggedMetricRegistry registry;
 
     private VisibilityMetrics(TaggedMetricRegistry registry) {
@@ -39,12 +46,7 @@ final class VisibilityMetrics {
     }
 
     static MetricName testMetricName() {
-        return MetricName.builder()
-                .safeName("visibility.test")
-                .putSafeTags("libraryName", LIBRARY_NAME)
-                .putSafeTags("libraryVersion", LIBRARY_VERSION)
-                .putSafeTags("javaVersion", JAVA_VERSION)
-                .build();
+        return testMetricName;
     }
 
     /**


### PR DESCRIPTION
## Before this PR

Calling the metric or metric name method constructs a new `MetricName` instance on every invocation.

## After this PR

Calling the metric or metric name method will reuse an existing `MetricName` when there are no metric tags.
- If there are no namespace tags, then the cached `MetricName` will be a static field
- If there are namespace tags, then the cache `MetricName` will be a non-static field

I didn't bother handling the case where all metric tags have a single value because it's a relatively obscure case and would add non-trivial complexity to the implementation.