### PR TITLE
Metric markdown includes missing tag docs for tags without enumerated values

### DIFF
--- a/changelog/@unreleased/pr-1064.v2.yml
+++ b/changelog/@unreleased/pr-1064.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Metric markdown includes missing tag docs for tags without enumerated
+    values
+  links:
+  - https://github.com/palantir/metric-schema/pull/1064

--- a/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
+++ b/metric-schema-markdown/src/main/java/com/palantir/metric/schema/markdown/MarkdownRenderer.java
@@ -87,8 +87,7 @@ public final class MarkdownRenderer {
                 .addAll(metric.getTagDefinitions())
                 .build();
         output.append("- `").append(namespace).append('.').append(metricName).append('`');
-        boolean hasComplexTags =
-                allTags.stream().anyMatch(definition -> !definition.getValues().isEmpty());
+        boolean hasComplexTags = hasComplexTags(allTags);
         if (!metric.getTags().isEmpty()) {
             output.append(" tagged ")
                     .append(metric.getTags().stream()
@@ -109,6 +108,12 @@ public final class MarkdownRenderer {
         if (hasComplexTags) {
             renderComplexTags(allTags, output);
         }
+    }
+
+    private static boolean hasComplexTags(List<TagDefinition> tags) {
+        return tags.stream()
+                .anyMatch(definition -> definition.getDocs().isPresent()
+                        || !definition.getValues().isEmpty());
     }
 
     private static void renderComplexTags(List<TagDefinition> tagDefinitions, StringBuilder output) {

--- a/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
+++ b/metric-schema-markdown/src/test/java/com/palantir/metric/schema/markdown/MarkdownRendererTest.java
@@ -247,6 +247,37 @@ class MarkdownRendererTest {
     }
 
     @Test
+    void testTaggedWithDocsOnlyOnTag() {
+        MetricSchema schema = MetricSchema.builder()
+                .namespaces(
+                        "namespace",
+                        MetricNamespace.builder()
+                                .docs(Documentation.of("namespace docs"))
+                                .metrics(
+                                        "metric",
+                                        MetricDefinition.builder()
+                                                .type(MetricType.METER)
+                                                .tagDefinitions(TagDefinition.builder()
+                                                        .name("result")
+                                                        .docs(Documentation.of("This is a result tag"))
+                                                        .build())
+                                                .docs(Documentation.of("metric docs"))
+                                                .build())
+                                .build())
+                .build();
+        String markdown = MarkdownRenderer.render(
+                "com.palantir:test", ImmutableMap.of("com.palantir:test:1.0.0", ImmutableList.of(schema)));
+        assertThat(markdown)
+                .isEqualTo("# Metrics\n\n"
+                        + "## Test\n\n"
+                        + "`com.palantir:test`\n\n"
+                        + "### namespace\n"
+                        + "namespace docs\n"
+                        + "- `namespace.metric` (meter): metric docs\n"
+                        + "  - `result`: This is a result tag");
+    }
+
+    @Test
     void testEmptyNamespacesExcluded() {
         String markdown = MarkdownRenderer.render(
                 "com.palantir:test",


### PR DESCRIPTION
==COMMIT_MSG==
Metric markdown includes missing tag docs for tags without enumerated values
==COMMIT_MSG==