### PR TITLE
MetricSchemaPlugin declares sourcesJar dependency on metric generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,11 @@ subprojects {
     apply plugin: 'com.palantir.baseline-class-uniqueness'
 
     tasks.withType(JavaCompile) {
-        options.compilerArgs += ['-Werror']
+        options.compilerArgs += [
+            '-Werror',
+            '-Xlint:deprecation',
+            '-Xlint:unchecked',
+        ]
     }
 
     tasks.check.dependsOn(javadoc)

--- a/changelog/@unreleased/pr-1092.v2.yml
+++ b/changelog/@unreleased/pr-1092.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: MetricSchemaPlugin declares sourcesJar dependency on metric generation
+  links:
+  - https://github.com/palantir/metric-schema/pull/1092

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CheckMetricMarkdownTask.java
@@ -76,8 +76,7 @@ public class CheckMetricMarkdownTask extends DefaultTask {
     public final void check() throws IOException {
         File manifest = getManifestFile().getAsFile().get();
 
-        Map<String, List<MetricSchema>> schemas =
-                ObjectMappers.mapper.readValue(manifest, new TypeReference<Map<String, List<MetricSchema>>>() {});
+        Map<String, List<MetricSchema>> schemas = ObjectMappers.mapper.readValue(manifest, new TypeReference<>() {});
         if (isEmpty(schemas)) {
             return;
         }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/CreateMetricsManifestTask.java
@@ -194,8 +194,7 @@ public class CreateMetricsManifestTask extends DefaultTask {
             return Optional.empty();
         }
 
-        try {
-            ZipFile zipFile = new ZipFile(artifact.getFile());
+        try (ZipFile zipFile = new ZipFile(artifact.getFile())) {
             ZipEntry manifestEntry = zipFile.getEntry(MetricSchemaPlugin.METRIC_SCHEMA_RESOURCE);
             if (manifestEntry == null) {
                 log.debug("Manifest file does not exist in JAR: {}", id);
@@ -203,7 +202,7 @@ public class CreateMetricsManifestTask extends DefaultTask {
             }
 
             try (InputStream is = zipFile.getInputStream(manifestEntry)) {
-                return Optional.of(ObjectMappers.mapper.readValue(is, new TypeReference<List<MetricSchema>>() {}));
+                return Optional.of(ObjectMappers.mapper.readValue(is, new TypeReference<>() {}));
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to load external monitors");

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricMarkdownTask.java
@@ -77,8 +77,7 @@ public class GenerateMetricMarkdownTask extends DefaultTask {
         File markdown = outputFile.get().getAsFile();
         File manifest = getManifestFile().getAsFile().get();
 
-        Map<String, List<MetricSchema>> schemas =
-                ObjectMappers.mapper.readValue(manifest, new TypeReference<Map<String, List<MetricSchema>>>() {});
+        Map<String, List<MetricSchema>> schemas = ObjectMappers.mapper.readValue(manifest, new TypeReference<>() {});
         if (isEmpty(schemas)) {
             if (markdown.exists()) {
                 markdown.delete();

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -61,11 +61,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                     task.getOutputDir().set(generatedJavaOutputDir);
                 });
 
-        SourceSet mainSourceSet = getMainSourceSet(project);
-        mainSourceSet.getJava().srcDirs(generateMetricsTask);
-        project.getTasks()
-                .named(mainSourceSet.getCompileJavaTaskName())
-                .configure(compileJava -> compileJava.dependsOn(generateMetricsTask));
+        getMainSourceSet(project).getJava().srcDir(generateMetricsTask);
         configureIdea(project, generateMetricsTask, generatedJavaOutputDir);
         configureEclipse(project, generateMetricsTask);
         configureProjectDependencies(project);

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -62,7 +62,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                 });
 
         SourceSet mainSourceSet = getMainSourceSet(project);
-        mainSourceSet.getJava().srcDirs(generatedJavaOutputDir, generateMetricsTask);
+        mainSourceSet.getJava().srcDirs(generateMetricsTask);
         project.getTasks()
                 .named(mainSourceSet.getCompileJavaTaskName())
                 .configure(compileJava -> compileJava.dependsOn(generateMetricsTask));

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/ObjectMappers.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/ObjectMappers.java
@@ -29,7 +29,7 @@ final class ObjectMappers {
 
     static List<MetricSchema> loadMetricSchema(File file) {
         try {
-            return ObjectMappers.mapper.readValue(file, new TypeReference<List<MetricSchema>>() {});
+            return ObjectMappers.mapper.readValue(file, new TypeReference<>() {});
         } catch (IOException e) {
             throw new GradleException("Failed to load metrics from file: " + file, e);
         }

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagDefinition.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagDefinition.java
@@ -37,6 +37,7 @@ public interface TagDefinition {
 
     final class TagDefinitionDeserializer extends JsonDeserializer<TagDefinition> {
         @Override
+        @SuppressWarnings("deprecation") // internal use permitted
         public TagDefinition deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
             if (parser.currentToken() == JsonToken.VALUE_STRING) {
                 String name = parser.getValueAsString();

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagValue.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/TagValue.java
@@ -34,6 +34,7 @@ public interface TagValue {
 
     final class TagValueDeserializer extends JsonDeserializer<TagValue> {
         @Override
+        @SuppressWarnings("deprecation") // internal use permitted
         public TagValue deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
             if (parser.currentToken() == JsonToken.VALUE_STRING) {
                 String value = parser.getValueAsString();


### PR DESCRIPTION
## Before this PR

Gradle 8 excavator https://github.com/palantir/tritium/pull/1861 [is failing](https://app.circleci.com/pipelines/github/palantir/tritium/3293/workflows/bbf0278a-b7a2-4a03-a8d4-4efd78e301e5/jobs/20615) due to missing task dependency for `sourcesJar` task on metrics generation.

```
> Task :tritium-lib:sourcesJar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':tritium-lib:sourcesJar' (type 'Jar').
  - Gradle detected a problem with the following location: '/home/circleci/project/tritium-lib/build/metricSchema/generated_src'.
    
    Reason: Task ':tritium-lib:sourcesJar' uses this output of task ':tritium-lib:generateMetrics' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':tritium-lib:generateMetrics' as an input of ':tritium-lib:sourcesJar'.
      2. Declare an explicit dependency on ':tritium-lib:generateMetrics' from ':tritium-lib:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':tritium-lib:generateMetrics' from ':tritium-lib:sourcesJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.5/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/home/circleci/project/tritium-lib/build/metricSchema'.
    
    Reason: Task ':tritium-lib:sourcesJar' uses this output of task ':tritium-lib:compileMetricSchema' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':tritium-lib:compileMetricSchema' as an input of ':tritium-lib:sourcesJar'.
      2. Declare an explicit dependency on ':tritium-lib:compileMetricSchema' from ':tritium-lib:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':tritium-lib:compileMetricSchema' from ':tritium-lib:sourcesJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.5/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

## After this PR
==COMMIT_MSG==
MetricSchemaPlugin declares sourcesJar dependency on metric generation.

Migrate away from Gradle deprecated `JavaPluginConvention` to `JavaPluginExtension` for Gradle 8 compatibility.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->