### PR TITLE
Use camel case for generated directory name

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -45,9 +45,9 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
 
         Provider<Directory> generatedJavaDir =
-                project.getLayout().getBuildDirectory().dir("generated/sources/metric-schema/java/main");
+                project.getLayout().getBuildDirectory().dir("generated/sources/metricSchema/java/main");
         Provider<Directory> generatedResourcesDir =
-                project.getLayout().getBuildDirectory().dir("generated/sources/metric-schema/resources/main");
+                project.getLayout().getBuildDirectory().dir("generated/sources/metricSchema/resources/main");
         Provider<Directory> metricSchemaDir =
                 project.getLayout().getBuildDirectory().dir("metricSchema");
 

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -101,7 +101,7 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         then:
         def result = runTasksSuccessfully('classes')
         result.wasExecuted(':generateMetrics')
-        fileExists("build/generated/sources/metric-schema/java/main/com/palantir/test/ServerMetrics.java")
+        fileExists("build/generated/sources/metricSchema/java/main/com/palantir/test/ServerMetrics.java")
     }
 
     def 'build cache works'() {
@@ -110,7 +110,7 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         file('src/main/metrics/metrics.yml') << METRICS
 
         runTasksSuccessfully('generateMetrics')
-        fileExists("build/generated/sources/metric-schema/java/main/com/palantir/test/ServerMetrics.java")
+        fileExists("build/generated/sources/metricSchema/java/main/com/palantir/test/ServerMetrics.java")
 
         // we want cache hits no matter where the project is checked out on disk
         File originalProjectDir = getProjectDir()
@@ -119,7 +119,7 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         FileUtils.copyDirectory(originalProjectDir, newProjectDir)
         setProjectDir(newProjectDir)
         FileUtils.deleteDirectory(originalProjectDir)
-        FileUtils.deleteDirectory(file("build/generated/sources/metric-schema"))
+        FileUtils.deleteDirectory(file("build/generated/sources/metricSchema"))
 
         then:
         ExecutionResult result = runTasksSuccessfully('generateMetrics')


### PR DESCRIPTION
Small FLUP from https://github.com/palantir/metric-schema/pull/1160

This follows the convention (ex. the annotation processor output directory is `annotationProcessor`).