### PR TITLE
Generate TaggedMetricRegistry registry() method

### DIFF
--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MonitorsMetrics.java
@@ -25,6 +25,13 @@ public final class MonitorsMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     public static MonitorsMetrics of(TaggedMetricRegistry registry) {
         return new MonitorsMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/MyNamespaceMetrics.java
@@ -33,6 +33,13 @@ public final class MyNamespaceMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     public static MyNamespaceMetrics of(TaggedMetricRegistry registry) {
         return new MyNamespaceMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/NamespaceTagsMetrics.java
@@ -71,6 +71,13 @@ public final class NamespaceTagsMetrics {
                 .build();
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     @CheckReturnValue
     public static NamespaceTagsBuilderRegistryStage builder() {
         return new NamespaceTagsBuilder();

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ProvidedVersionMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ProvidedVersionMetrics.java
@@ -28,6 +28,13 @@ public final class ProvidedVersionMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     public static ProvidedVersionMetrics of(TaggedMetricRegistry registry) {
         return new ProvidedVersionMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ReservedConflictMetrics.java
@@ -34,6 +34,13 @@ public final class ReservedConflictMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     public static ReservedConflictMetrics of(TaggedMetricRegistry registry) {
         return new ReservedConflictMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/ServerMetrics.java
@@ -33,6 +33,13 @@ public final class ServerMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     public static ServerMetrics of(TaggedMetricRegistry registry) {
         return new ServerMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
     }

--- a/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
+++ b/metric-schema-java/src/integrationInput/java/com/palantir/test/VisibilityMetrics.java
@@ -33,6 +33,13 @@ final class VisibilityMetrics {
         this.registry = registry;
     }
 
+    /**
+     * Returns the tagged metric registry backing this object.
+     */
+    public TaggedMetricRegistry registry() {
+        return registry;
+    }
+
     static VisibilityMetrics of(TaggedMetricRegistry registry) {
         return new VisibilityMetrics(Preconditions.checkNotNull(registry, "TaggedMetricRegistry"));
     }

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/UtilityGenerator.java
@@ -59,6 +59,12 @@ final class UtilityGenerator {
                 .addModifiers(visibility.apply(Modifier.FINAL))
                 .addJavadoc(Javadoc.render(metrics.getDocs()))
                 .addField(TaggedMetricRegistry.class, ReservedNames.REGISTRY_NAME, Modifier.PRIVATE, Modifier.FINAL)
+                .addMethod(MethodSpec.methodBuilder(ReservedNames.REGISTRY_NAME)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Returns the tagged metric registry backing this object.")
+                        .returns(TaggedMetricRegistry.class)
+                        .addStatement("return $N", ReservedNames.REGISTRY_NAME)
+                        .build())
                 .addField(FieldSpec.builder(
                                 String.class,
                                 ReservedNames.JAVA_VERSION_FIELD,


### PR DESCRIPTION
## Before this PR

The generated metrics classes do not expose a mechanism to interact with the underlying `TaggedMetricRegistry`. This is needed for example to unregister metrics.

## After this PR
==COMMIT_MSG==
Generate TaggedMetricRegistry registry() method
==COMMIT_MSG==

## Possible downsides?
This breaks encapsulation of the `TaggedMetricRegistry`