### PR TITLE
Remove use of getProject() from task execution

### DIFF
--- a/changelog/@unreleased/pr-1335.v2.yml
+++ b/changelog/@unreleased/pr-1335.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+improvement:
+  description: Remove usage of getProject() during task execution.
+  links:
+  - https://github.com/palantir/metric-schema/pull/1335

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
@@ -48,7 +48,7 @@ public abstract class GenerateMetricsTask extends DefaultTask {
     public abstract RegularFileProperty getInputFile();
 
     @Input
-    public abstract Property<String> getProjectGroup();
+    public abstract Property<String> getPackageName();
 
     @Input
     @org.gradle.api.tasks.Optional

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
@@ -72,7 +72,7 @@ public abstract class GenerateMetricsTask extends DefaultTask {
                 .libraryName(Optional.ofNullable(getLibraryName().getOrNull()))
                 .libraryVersion(Optional.ofNullable(getLibraryVersion().getOrNull()))
                 // TODO(forozco): probably want something better
-                .defaultPackageName(getProjectGroup().get())
+                .defaultPackageName(getPackageName().get())
                 .build());
     }
 

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
@@ -71,7 +71,6 @@ public abstract class GenerateMetricsTask extends DefaultTask {
                 .output(output.toPath())
                 .libraryName(Optional.ofNullable(getLibraryName().getOrNull()))
                 .libraryVersion(Optional.ofNullable(getLibraryVersion().getOrNull()))
-                // TODO(forozco): probably want something better
                 .defaultPackageName(getPackageName().get())
                 .build());
     }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/GenerateMetricsTask.java
@@ -48,6 +48,9 @@ public abstract class GenerateMetricsTask extends DefaultTask {
     public abstract RegularFileProperty getInputFile();
 
     @Input
+    public abstract Property<String> getProjectGroup();
+
+    @Input
     @org.gradle.api.tasks.Optional
     public abstract Property<String> getLibraryName();
 
@@ -62,7 +65,6 @@ public abstract class GenerateMetricsTask extends DefaultTask {
     public final void generate() {
         File output = getOutputDir().getAsFile().get();
         clearOutput(output.toPath());
-        getProject().mkdir(output);
 
         JavaGenerator.generate(JavaGeneratorArgs.builder()
                 .input(getInputFile().getAsFile().get().toPath())
@@ -70,7 +72,7 @@ public abstract class GenerateMetricsTask extends DefaultTask {
                 .libraryName(Optional.ofNullable(getLibraryName().getOrNull()))
                 .libraryVersion(Optional.ofNullable(getLibraryVersion().getOrNull()))
                 // TODO(forozco): probably want something better
-                .defaultPackageName(getProject().getGroup().toString())
+                .defaultPackageName(getProjectGroup().get())
                 .build());
     }
 

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -74,7 +74,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                     task.getLibraryName().convention(defaultLibraryName(project));
                     task.getLibraryVersion().convention(defaultLibraryVersion(project));
                     task.getOutputDir().set(generatedJavaDir);
-                    task.getProjectGroup().set(project.getGroup().toString());
+                    task.getPackageName().set(project.getGroup().toString());
                 });
 
         project.getTasks().register(CreateMetricsManifestTask.NAME, CreateMetricsManifestTask.class, task -> {

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -74,6 +74,7 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
                     task.getLibraryName().convention(defaultLibraryName(project));
                     task.getLibraryVersion().convention(defaultLibraryVersion(project));
                     task.getOutputDir().set(generatedJavaDir);
+                    task.getProjectGroup().set(project.getGroup().toString());
                 });
 
         project.getTasks().register(CreateMetricsManifestTask.NAME, CreateMetricsManifestTask.class, task -> {


### PR DESCRIPTION
## Before this PR
When running with Gradle 8.10+ (and plausibly earlier) I see the following error:
```
- Task `:myproj:generateMetrics` of type `com.palantir.metric.schema.gradle.GenerateMetricsTask`: invocation of 'Task.project' at execution time is unsupported.
46 actionable tasks: 44 executed, 2 from cache
  See https://docs.gradle.org/8.13/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
```

## After this PR
==COMMIT_MSG==
Remove usage of getProject() during task execution.
==COMMIT_MSG==

## Possible downsides?
None
