### PR TITLE
Fix broken changelog in #1335

### DIFF
--- a/changelog/@unreleased/pr-1335.v2.yml
+++ b/changelog/@unreleased/pr-1335.v2.yml
@@ -1,5 +1,5 @@
 type: fix
-improvement:
+fix:
   description: Remove usage of getProject() during task execution.
   links:
   - https://github.com/palantir/metric-schema/pull/1335


### PR DESCRIPTION
## Before this PR
#1335 had a broken changelog entry, so autorelease is failing https://github.com/palantir/metric-schema/pull/1335#issuecomment-2749592860

## After this PR
==COMMIT_MSG==
Fix #1335's broken change log.
==COMMIT_MSG==

## Possible downsides?
