### PR TITLE
Do not declare project dependencies if there is no code to generate

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -101,7 +101,10 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
 
         configureIdea(project, generatedJavaDir, generatedResourcesDir);
 
-        configureProjectDependencies(project);
+        // Only add dependencies if we're going to generate code
+        if (!metricSchemaSourceDirectorySet.getFiles().isEmpty()) {
+            configureProjectDependencies(project);
+        }
     }
 
     private static void configureIdea(
@@ -125,8 +128,9 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
         project.getDependencies().add("api", "com.palantir.tritium:tritium-registry");
         project.getDependencies().add("api", "com.palantir.safe-logging:preconditions");
         project.getDependencies().add("api", "com.google.errorprone:error_prone_annotations");
+        // Metric types like Gauge are part of the generated code's public API
+        project.getDependencies().add("api", "io.dropwizard.metrics:metrics-core");
         project.getDependencies().add("implementation", "com.palantir.safe-logging:safe-logging");
-        project.getDependencies().add("implementation", "io.dropwizard.metrics:metrics-core");
     }
 
     private String defaultLibraryName(Project project) {

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -357,4 +357,23 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(":checkUnusedDependenciesMain")
         !result.wasSkipped(":checkUnusedDependenciesMain")
     }
+
+    def 'declare exact dependencies even without generated metrics'() {
+        setup:
+        buildFile << """
+        apply plugin: 'com.palantir.baseline'
+        """.stripIndent(true)
+
+        when:
+        ExecutionResult result = runTasksSuccessfully("classes", "checkImplicitDependencies", "checkUnusedDependencies")
+
+        then:
+        result.wasExecuted(':generateMetrics')
+        !fileExists("build/generated/sources/metricSchema/java/main/com/palantir/test/ServerMetrics.java")
+
+        result.wasExecuted(":checkImplicitDependenciesMain")
+        !result.wasSkipped(":checkImplicitDependenciesMain")
+        result.wasExecuted(":checkUnusedDependenciesMain")
+        !result.wasSkipped(":checkUnusedDependenciesMain")
+    }
 }


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/metric-schema/pull/1443 introduced two missing dependencies. However, because they were declared as `implementation`, this caused some setups to fail the `checkUnusedDependencies` tasks, in the case where there is `metrics.yml` file and thus no code to generate and use the dependencies (this setup exists in services that still generate the `metrics.md` file even if they themselves don't add new metrics)

## After this PR
==COMMIT_MSG==
Do not declare project dependencies if there is no code to generate
==COMMIT_MSG==

It also turns out that `metrics-core` was actually part of the public API of the generated code, so I updated it to be declared as API rather than implementation.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

