### PR TITLE
Ignore safe-logging dep if unused + replace Strings.CS usage

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/DependencyRequirements.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/DependencyRequirements.java
@@ -24,14 +24,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 public final class DependencyRequirements {
 
-    public static Multimap<String, String> getDependencies(Collection<File> metricSchemaFiles) {
-        if (metricSchemaFiles == null || metricSchemaFiles.isEmpty()) {
-            return ImmutableSetMultimap.of();
-        }
-
+    public static Multimap<String, String> getDependencies(@Nonnull Collection<File> metricSchemaFiles) {
         Collection<LangMetricSchema> rawSchemas = metricSchemaFiles.stream()
                 .<Optional<LangMetricSchema>>map(schemaFile -> {
                     try {
@@ -44,8 +41,7 @@ public final class DependencyRequirements {
                 .<LangMetricSchema>mapMulti(Optional::ifPresent)
                 .toList();
 
-        if (rawSchemas.isEmpty()
-                || rawSchemas.stream().allMatch(schema -> schema.namespaces().isEmpty())) {
+        if (rawSchemas.stream().allMatch(schema -> schema.namespaces().isEmpty())) {
             // There isn't anything to generate, so no dependencies are required.
             return ImmutableSetMultimap.of();
         }

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/DependencyRequirements.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/DependencyRequirements.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.metric.schema;
+package com.palantir.metric.schema.gradle;
 
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -16,7 +16,8 @@
 
 package com.palantir.metric.schema.gradle;
 
-import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Multimap;
+import com.palantir.metric.schema.DependencyRequirements;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.sls.versions.SlsVersion;
 import com.palantir.sls.versions.SlsVersionType;
@@ -26,7 +27,7 @@ import javax.annotation.Nullable;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
-import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaLibraryPlugin;
@@ -118,33 +119,20 @@ public final class MetricSchemaPlugin implements Plugin<Project> {
         });
     }
 
-    private static void configureDependencies(Project project, FileCollection metricSchemaSourceDirectorySet) {
-        ImmutableSetMultimap<String, String> allDependencies = ImmutableSetMultimap.<String, String>builder()
-                .put("api", "com.palantir.tritium:tritium-registry")
-                .put("api", "com.palantir.safe-logging:preconditions")
-                .put("api", "com.google.errorprone:error_prone_annotations")
-                // Metric types like Gauge are part of the generated code's public API
-                .put("api", "io.dropwizard.metrics:metrics-core")
-                .put("implementation", "com.palantir.safe-logging:safe-logging")
-                .build();
+    private static void configureDependencies(Project project, SourceDirectorySet metricSchemaSourceDirectorySet) {
+        Provider<Multimap<String, String>> dependencies = metricSchemaSourceDirectorySet
+                .getElements()
+                .map(metricsFiles -> DependencyRequirements.getDependencies(
+                        metricsFiles.stream().map(FileSystemLocation::getAsFile).toList()));
 
-        allDependencies.asMap().forEach((configurationName, dependencies) -> {
-            project.getConfigurations().named(configurationName, configuration -> {
-                configuration
-                        .getDependencies()
-                        .addAllLater(
-                                metricSchemaSourceDirectorySet.getElements().map(files -> {
-                                    // Don't add dependencies if we're not going to generate code
-                                    if (files.isEmpty()) {
-                                        return List.of();
-                                    }
-
-                                    return dependencies.stream()
-                                            .map(project.getDependencies()::create)
-                                            .toList();
-                                }));
-            });
-        });
+        List.of(JavaPlugin.API_CONFIGURATION_NAME, JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+                .forEach(configurationName -> project.getConfigurations().named(configurationName, configuration -> {
+                    configuration
+                            .getDependencies()
+                            .addAllLater(dependencies.map(deps -> deps.get(configurationName).stream()
+                                    .map(project.getDependencies()::create)
+                                    .toList()));
+                }));
     }
 
     private String defaultLibraryName(Project project) {

--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/MetricSchemaPlugin.java
@@ -17,7 +17,6 @@
 package com.palantir.metric.schema.gradle;
 
 import com.google.common.collect.Multimap;
-import com.palantir.metric.schema.DependencyRequirements;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.sls.versions.SlsVersion;
 import com.palantir.sls.versions.SlsVersionType;

--- a/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
+++ b/gradle-metric-schema/src/test/groovy/com/palantir/metric/schema/gradle/MetricSchemaPluginIntegrationSpec.groovy
@@ -44,6 +44,16 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
                 docs: A gauge of the ratio of active workers to the number of workers.
         """.stripIndent()
 
+    public static final String METRICS_NO_TAGS = """
+        namespaces:
+          server:
+            docs: General web server metrics.
+            metrics:
+              worker.utilization:
+                type: gauge
+                docs: A gauge of the ratio of active workers to the number of workers.
+        """.stripIndent()
+
     public static final String METRICS_INVALID = """
         namespaces:
           server:
@@ -370,6 +380,26 @@ class MetricSchemaPluginIntegrationSpec extends IntegrationSpec {
         then:
         result.wasExecuted(':generateMetrics')
         !fileExists("build/generated/sources/metricSchema/java/main/com/palantir/test/ServerMetrics.java")
+
+        result.wasExecuted(":checkImplicitDependenciesMain")
+        !result.wasSkipped(":checkImplicitDependenciesMain")
+        result.wasExecuted(":checkUnusedDependenciesMain")
+        !result.wasSkipped(":checkUnusedDependenciesMain")
+    }
+
+    def 'declare exact dependencies even with metrics without safety-annotated tags'() {
+        setup:
+        buildFile << """
+        apply plugin: 'com.palantir.baseline'
+        """.stripIndent(true)
+        file('src/main/metrics/metrics.yml') << METRICS_NO_TAGS
+
+        when:
+        ExecutionResult result = runTasksSuccessfully("classes", "checkImplicitDependencies", "checkUnusedDependencies")
+
+        then:
+        result.wasExecuted(':generateMetrics')
+        fileExists("build/generated/sources/metricSchema/java/main/com/palantir/test/ServerMetrics.java")
 
         result.wasExecuted(":checkImplicitDependenciesMain")
         !result.wasSkipped(":checkImplicitDependenciesMain")

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/DependencyRequirements.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/DependencyRequirements.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.metric.schema;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Multimap;
+import com.palantir.metric.schema.lang.LangMetricSchema;
+import com.palantir.metric.schema.lang.MetricSchemaCompiler;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+public final class DependencyRequirements {
+
+    public static Multimap<String, String> getDependencies(Collection<File> metricSchemaFiles) {
+        if (metricSchemaFiles == null || metricSchemaFiles.isEmpty()) {
+            return ImmutableSetMultimap.of();
+        }
+
+        Collection<LangMetricSchema> rawSchemas = metricSchemaFiles.stream()
+                .<Optional<LangMetricSchema>>map(schemaFile -> {
+                    try {
+                        return Optional.of(MetricSchemaCompiler.parseRawSchema(schemaFile));
+                    } catch (IOException e) {
+                        // for configuration purposes, ignore files that cannot be parsed as schemas
+                        return Optional.empty();
+                    }
+                })
+                .<LangMetricSchema>mapMulti(Optional::ifPresent)
+                .toList();
+
+        if (rawSchemas.isEmpty()
+                || rawSchemas.stream().allMatch(schema -> schema.namespaces().isEmpty())) {
+            // There isn't anything to generate, so no dependencies are required.
+            return ImmutableSetMultimap.of();
+        }
+
+        ImmutableSetMultimap.Builder<String, String> dependencies = ImmutableSetMultimap.<String, String>builder()
+                .put("api", "com.palantir.tritium:tritium-registry")
+                .put("api", "com.palantir.safe-logging:preconditions")
+                .put("api", "com.google.errorprone:error_prone_annotations")
+                // Metric types like Gauge are part of the generated code's public API
+                .put("api", "io.dropwizard.metrics:metrics-core");
+        if (requiresSafeLogging(rawSchemas)) {
+            dependencies.put("implementation", "com.palantir.safe-logging:safe-logging");
+        }
+        return dependencies.build();
+    }
+
+    /**
+     * Determines whether any of the provided schemas require the com.palantir.safe-logging:safe-logging dependency.
+     */
+    private static boolean requiresSafeLogging(Collection<LangMetricSchema> schemas) {
+        return schemas.stream()
+                .flatMap(schema -> schema.namespaces().values().stream())
+                .flatMap(namespace -> namespace.metrics().values().stream())
+                .anyMatch(metric -> !metric.tags().isEmpty());
+    }
+
+    private DependencyRequirements() {}
+}

--- a/metric-schema-java/src/main/java/com/palantir/metric/schema/Javadoc.java
+++ b/metric-schema-java/src/main/java/com/palantir/metric/schema/Javadoc.java
@@ -17,7 +17,6 @@
 package com.palantir.metric.schema;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Strings;
 import org.commonmark.node.Paragraph;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.Renderer;
@@ -55,7 +54,10 @@ final class Javadoc {
             return "";
         }
         String renderedHtml = renderer.render(parser.parse(rawDocumentation));
-        return Strings.CS.appendIfMissing(renderedHtml, "\n");
+        if (!renderedHtml.endsWith("\n")) {
+            renderedHtml += "\n";
+        }
+        return renderedHtml;
     }
 
     private Javadoc() {}

--- a/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/MetricSchemaCompiler.java
+++ b/metric-schema-lang/src/main/java/com/palantir/metric/schema/lang/MetricSchemaCompiler.java
@@ -39,10 +39,14 @@ public final class MetricSchemaCompiler {
 
     private static MetricSchema readFile(File file) {
         try {
-            return LangConverter.toApi(reader.readValue(file));
+            return LangConverter.toApi(parseRawSchema(file));
         } catch (IOException e) {
             throw new SafeUncheckedIoException("Failed to deserialize file", e, SafeArg.of("file", file));
         }
+    }
+
+    public static LangMetricSchema parseRawSchema(File inputFile) throws IOException {
+        return reader.readValue(inputFile);
     }
 
     private MetricSchemaCompiler() {}


### PR DESCRIPTION
## Before this PR
It seems like https://github.com/palantir/metric-schema/pull/1544 (and subsequent https://github.com/palantir/metric-schema/pull/1545) were not quite enough, as there are cases where we actually generate code, but do not in fact need the safe-logging dependency (specifically if no tags are used).

Additionally, there seems to be a bug where we fail with e.g.
```
class org.apache.commons.lang3.Strings tried to access method 'boolean org.apache.commons.lang3.CharSequenceUtils.regionMatches(java.lang.CharSequence, boolean, int, java.lang.CharSequence, int, int)' (org.apache.commons.lang3.Strings is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @3d27b703; org.apache.commons.lang3.CharSequenceUtils is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @7bbc7fa0)

* Causal chain is:
	org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':resource-policy-enforcer:generateMetrics'.
	java.lang.IllegalAccessError: class org.apache.commons.lang3.Strings tried to access method 'boolean org.apache.commons.lang3.CharSequenceUtils.regionMatches(java.lang.CharSequence, boolean, int, java.lang.CharSequence, int, int)' (org.apache.commons.lang3.Strings is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @3d27b703; org.apache.commons.lang3.CharSequenceUtils is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @7bbc7fa0)
```
when calling `Strings.CS.appendIfMissing`. Considering how trivial the logic is, it's simpler to just inline it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ignore safe-logging dep if unused + replace Strings.CS usage
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

