### PR TITLE
Add a dependency on a specific version of tritium-registry

### DIFF
--- a/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/DependencyRequirements.java
+++ b/gradle-metric-schema/src/main/java/com/palantir/metric/schema/gradle/DependencyRequirements.java
@@ -47,7 +47,8 @@ public final class DependencyRequirements {
         }
 
         ImmutableSetMultimap.Builder<String, String> dependencies = ImmutableSetMultimap.<String, String>builder()
-                .put("api", "com.palantir.tritium:tritium-registry")
+                // 0.130.0 has a new builder constructor that we depend on
+                .put("api", "com.palantir.tritium:tritium-registry:0.130.0")
                 .put("api", "com.palantir.safe-logging:preconditions")
                 .put("api", "com.google.errorprone:error_prone_annotations")
                 // Metric types like Gauge are part of the generated code's public API


### PR DESCRIPTION
## Before this PR
After https://github.com/palantir/metric-schema/pull/1772 we started depending on at least a specific version of tritium being present in the classpath (i.e. we require https://github.com/palantir/tritium/pull/2451). Let's enforce this through the gradle plugin.

Without this PR, trying to pick up only the metric-schema bump would fail at compile-time.
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

